### PR TITLE
`number_sign` section in blog posts

### DIFF
--- a/_posts/2024-07-10-number-formatter.adoc
+++ b/_posts/2024-07-10-number-formatter.adoc
@@ -331,6 +331,19 @@ are:
 ----
 ====
 
+`number_sign`:: (`Symbol` value)
+Specify whether to use a plus sign to explicitly denote positive numbers. Legal values are:
+
+`plus`::: The `+` symbol is used.
++
+.Using the plus sign to indicate positive numbers
+[example]
+====
+----
++32.232232
+----
+====
+
 These options are to be grouped under a single Hash object.
 
 .Format options Hash for `localizer_symbols`

--- a/_posts/2024-09-17-formula-number-formatting.adoc
+++ b/_posts/2024-09-17-formula-number-formatting.adoc
@@ -270,6 +270,10 @@ The default configuration for formatting numbers is as follows, set in the
 |The sign used for the exponent part of the number
 |`"plus"`
 
+|`number_sign`
+|The prefix for the positive numbers only.
+|`"plus"`
+
 |`fraction_group`
 |The character used to separate groups of digits in the fraction part
 |`"'"`


### PR DESCRIPTION
This PR adds a section supporting `number_sign` with `plus` as the only valid value in the **NumberFormatter** and **NumberFormatter for Plurimath::Math::Formula** blog posts.

closes #58 