### PR TITLE
Swap button and new UI for demo page

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:

--- a/demo.html
+++ b/demo.html
@@ -5,65 +5,259 @@ description: Demo.
 
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <title>Demo</title>
 
-    <style>
+<head>
+  <meta charset="utf-8">
+  <title>Demo</title>
+
+  <style>
+    form {
+      display: flex;
+      flex-direction: column;
+      row-gap: 1em;
+      padding: 1em 1em;
+      background-color: white;
+    }
+
+    form>* {
+      color: black;
+    }
+
+    form>div>* {
+      flex: 1;
+    }
+
+    #toggle-state {
+      text-align: center;
+      font-weight: bold;
+    }
+
+    .engine-toggler {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #input,
+    #output {
+      display: flex;
+      flex-direction: column;
+      gap: 10px !important;
+    }
+
+    #output {
+      align-items: flex-end;
+    }
+
+    #input>textarea,
+    #output>textarea {
+      width: 29.5vw;
+    }
+
+    @media (max-width: 500px) {
       form {
-        display: flex;
-        width: 70%;
+        width: 80%;
+      }
+    }
+
+    @media (max-width: 829px) {
+
+      form {
+        max-width: 88%;
+      }
+
+      #input>textarea,
+      #output>textarea {
+        width: 100%;
+      }
+
+      #output {
+        align-items: flex-start !important;
+      }
+
+      #io-section {
         flex-direction: column;
-        row-gap: 1em;
-        padding: 1em 1em;
-        background-color: white;
+        width: 100%;
       }
-      form>* {
-        color: black;
+
+      #swap-icon:before {
+        content: "\21c5" !important;
       }
-      form>div>* { flex: 1; }
-      textarea { min-height: 20vh; padding: 1rem; font-size: x-large; }
-      div#preview { font-size: x-large; padding: 1rem; border: 1px solid; }
-      form>label { margin-bottom: -1em; }
-      textarea#math_tree { font-size: small; }
-    </style>
-  </head>
-  <body>
-    <form>
-      <h2>Live Demo</h2>
-      <div>
-        <label>Input</label>&nbsp&nbsp
-        <select id="fromfmt">
-          <option value="asciimath">Asciimath</option>
-          <option value="omml">Omml</option>
-          <option value="html">Html</option>
-          <option value="mathml">Mathml</option>
-          <option value="latex">Latex</option>
-        </select>
+
+      #math_tree,
+      #preview {
+        width: 100%;
+      }
+
+      #options {
+        flex-wrap: wrap;
+        gap: .5rem;
+        padding-top: 1rem;
+      }
+    }
+
+    #io-section {
+      display: flex;
+      align-self: flex-start;
+      column-gap: .4rem;
+    }
+
+    #options {
+      display: flex;
+      flex-direction: column;
+      place-self: center;
+      align-content: center;
+      justify-items: center;
+      gap: 1rem;
+    }
+
+    textarea {
+      min-height: 20vh;
+      padding: 1rem;
+      font-size: x-large;
+    }
+
+    div#preview {
+      font-size: x-large;
+      padding: 1rem;
+      border: 1px solid;
+    }
+
+    form>label {
+      margin-bottom: -1em;
+    }
+
+    textarea#math_tree {
+      font-size: small;
+    }
+
+    .toggle {
+      position: relative;
+      display: inline-block;
+      margin-top: 0.5rem;
+      width: 50px;
+      height: 26px;
+      background-color: hsl(0, 0%, 85%);
+      border-radius: 25px;
+      cursor: pointer;
+      transition: background-color 0.25s ease-in;
+    }
+
+    .toggle::after {
+      content: '';
+      position: absolute;
+      top: 2px;
+      left: 2px;
+      width: 22px;
+      height: 22px;
+      background-color: white;
+      border-radius: 50%;
+      transition: all 0.25s ease-out;
+    }
+
+    #engine-toggle:checked+.toggle {
+      background-color: #6e31ed;
+    }
+
+    #engine-toggle:checked+.toggle::after {
+      transform: translateX(24px);
+    }
+
+    .hide-me {
+      opacity: 0;
+      height: 0;
+      width: 0;
+    }
+
+    .button-1 {
+      background-color: transparent;
+      border-radius: 8px;
+      border-style: none;
+      box-sizing: border-box;
+      color: #6e31ed;
+      cursor: pointer;
+      display: inline-block;
+      font-family: "Haas Grot Text R Web", "Helvetica Neue", Helvetica, Arial, sans-serif;
+      font-size: 14px;
+      font-weight: 500;
+      height: 40px;
+      line-height: 20px;
+      list-style: none;
+      margin: 0;
+      outline: none;
+      padding: 10px 16px;
+      position: relative;
+      text-align: center;
+      text-decoration: none;
+      transition: color 100ms;
+      vertical-align: baseline;
+      user-select: none;
+      -webkit-user-select: none;
+      touch-action: manipulation;
+    }
+
+    #swap-button {
+      display: flex;
+      flex-direction: column;
+    }
+
+    #swap-icon:before {
+      font-size: 30px;
+      font-style: normal;
+      content: "\21c4";
+    }
+  </style>
+</head>
+
+<body>
+  <form>
+    <h2>Live Demo</h2>
+    <div id="io-section">
+      <div id="input">
+        <div id="input-options">
+          <label>Input</label>&nbsp&nbsp
+          <select id="fromfmt">
+            <option value="asciimath">Asciimath</option>
+            <option value="omml">Omml</option>
+            <option value="html">Html</option>
+            <option value="mathml">Mathml</option>
+            <option value="latex">Latex</option>
+          </select>
+        </div>
+        <!-- <textarea id="from">sum_(i=1)^n i^3=((n(n+1))/2)^2</textarea> -->
+        <textarea id="from"></textarea>
       </div>
-      <textarea id="from">sum_(i=1)^n i^3=((n(n+1))/2)^2</textarea>
-      <div id="renderer">
-        <label>Rendering</label>
-        <select id="mathmlEngine">
-          <option value="mathjax" selected>MathJax</option>
-          <option value="mathml">Browser native</option>
-        </select>
+      <div id="options">
+        <div id="input-swapper">
+          <button id="swap-button" class="button-1" role="button"><i id="swap-icon"></i>Swap</button>
+        </div>
+        <div class="engine-toggler">
+          <input id="engine-toggle" type="checkbox" class="hide-me" checked>
+          <label for="engine-toggle" class="toggle"></label>
+          <div id="cb-label">
+            <span id="toggle-state">MathJax</span>
+          </div>
+        </div>
       </div>
-      <div id="preview"></div>
-      <div>
-        <label>Output</label>&nbsp&nbsp
-        <select id="tofmt">
-          <option value="Asciimath">Asciimath</option>
-          <option value="Omml">Omml</option>
-          <option value="Html">Html</option>
-          <option selected value="Mathml">Mathml</option>
-          <option value="Latex">Latex</option>
-        </select>
+      <div id="output">
+        <div id="output-options">
+          <label>Output</label>&nbsp&nbsp
+          <select id="tofmt">
+            <option value="Asciimath">Asciimath</option>
+            <option value="Omml">Omml</option>
+            <option value="Html">Html</option>
+            <option selected value="Mathml">Mathml</option>
+            <option value="Latex">Latex</option>
+          </select>
+        </div>
+        <textarea id="to" readonly></textarea>
       </div>
-      <textarea id="to" readonly></textarea>
-      <label>Rendering Tree</label>
-      <textarea id="math_tree" wrap="off" readonly></textarea>
-    </form>
-    <script src="./../javascript/demo.js" type="module"></script>
-  </body>
+    </div>
+    <div id="preview"></div>
+    <label>Rendering Tree</label>
+    <textarea id="math_tree" wrap="off" readonly></textarea>
+  </form>
+  <script src="./../javascript/demo.js" type="module"></script>
+</body>
+
 </html>

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -13,8 +13,7 @@ function convert(){
 }
 
 function changeEngine() {
-  const engine = document.getElementById("mathmlEngine");
-  const selectedValue = engine.selectedOptions[0].value
+  const selectedValue = currentEngine();
   if (selectedValue == "mathjax") { return insertMathJax() }
 
   const script = document.getElementById("MathJax-script");
@@ -45,18 +44,17 @@ function insertMathJax() {
   }
 }
 
-function inputTimeouts(event) {
+function inputTimeouts(event, callableFunction = convert) {
   if (event.timeout) { clearTimeout(event.timeout) };
-  event.timeout = setTimeout(convert, 1000);
+  event.timeout = setTimeout(callableFunction, 1000);
 }
 
-function converter(from_fmt) {
+function converter(from_fmt, mathmlEngine = currentEngine) {
   const to = document.getElementById("to");
   const from = document.getElementById("from");
   const tofmt = document.getElementById("tofmt").value;
   const pre_render = document.getElementById("preview");
   const math_tree  = document.getElementById("math_tree");
-  const selectedValue = document.getElementById("mathmlEngine").selectedOptions[0].value;
 
   // empty result
   to.value = "";
@@ -71,12 +69,16 @@ function converter(from_fmt) {
   pre_render.innerHTML = mathml;
   pre_render.setAttribute("math-content", mathml);
   math_tree.value = pm.toDisplay(tofmt.toLowerCase());
-  if (selectedValue === "mathjax" && MathJax.hasOwnProperty("typeset")) { MathJax.typeset(); }
+  if (mathmlEngine() === "mathjax" && MathJax.hasOwnProperty("typeset")) { MathJax.typeset(); }
   return [from, pm]
+}
+
+function currentEngine() {
+  return document.getElementById("mathmlEngine").selectedOptions[0].value
 }
 
 function capitalize(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-export { Initialize, converter, inputTimeouts, capitalize }
+export { Initialize, insertMathJax, converter, inputTimeouts, capitalize }

--- a/javascript/demo.js
+++ b/javascript/demo.js
@@ -1,7 +1,11 @@
-import { Initialize, converter, capitalize } from "./core.js";
+import { converter, insertMathJax, capitalize, inputTimeouts } from "./core.js";
 
 (() => {
-  Initialize();
+  document.addEventListener("DOMContentLoaded", demoConvert);
+  document.querySelector("#swap-button").addEventListener("click", swapInputOutput)
+  document.querySelector("#engine-toggle").addEventListener("change", updateEngineName);
+  document.querySelector("#from").addEventListener("input", function(event) { inputTimeouts(event, demoConvert) });
+  document.querySelector("#tofmt").addEventListener("change", function (event) { inputTimeouts(event, demoConvert) });
   document.querySelector("#fromfmt").addEventListener("focus", () => {
     event.target.dataset.pre_selected = event.target.value;
     document.removeEventListener("focus", event.target);
@@ -13,6 +17,50 @@ import { Initialize, converter, capitalize } from "./core.js";
 function changeInputValue() {
   const pre_selected = this.dataset.pre_selected;
   this.dataset.pre_selected = this.value;
-  const [from, pm] = converter(pre_selected)
+  const [from, pm] = converter(pre_selected, demoEngine)
   from.value = pm["to"+capitalize(this.value)]();
+}
+
+function changeDemoEngine() {
+  const isMathJax = demoEngine(true);
+  if (isMathJax) { return insertMathJax() }
+
+  const script = document.getElementById("MathJax-script");
+  if (!isMathJax && !script) return;
+
+  const preview = document.getElementById("preview")
+  document.head.removeChild(script);
+
+  preview.innerHTML = preview.getAttribute("math-content")
+}
+
+function demoConvert() {
+  changeDemoEngine();
+  converter(document.getElementById("fromfmt").value, demoEngine);
+}
+
+function updateEngineName() {
+  const engineNameElement = document.querySelector("#toggle-state")
+  engineNameElement.innerHTML = demoEngine(true) ? "MathJax" : "Browser native"
+  changeDemoEngine();
+}
+
+function demoEngine(returnBoolean = false) {
+  const isMathJax = document.getElementById("engine-toggle").checked
+  if (returnBoolean) { return isMathJax }
+
+  return isMathJax ? "mathjax" : "mathml" 
+}
+
+function swapInputOutput() {
+  event.preventDefault();
+  const toValueForFrom = document.querySelector("#to").value
+  const toFmt = document.querySelector("#tofmt")
+  const fromFmt = document.querySelector("#fromfmt")
+  const tofmtSelectedIndex = toFmt.selectedIndex
+  const fromFmtSelectedIndex = fromFmt.selectedIndex
+  document.querySelector("#from").value = toValueForFrom
+  toFmt.selectedIndex = fromFmtSelectedIndex
+  fromFmt.selectedIndex = tofmtSelectedIndex
+  demoConvert()
 }


### PR DESCRIPTION
This PR updates the **UI** of the `demo` page and adds a new button 'swap' for users to conveniently replace `input` values (dropdown and text field values) with `output` fields (dropdown value and read-only text field) content.

![localhost_4000_demo_ (1)](https://github.com/user-attachments/assets/8b1bf8e7-008c-4bca-9982-b09f611c5a4b)
![localhost_4000_demo_(iPhone XR)](https://github.com/user-attachments/assets/47a59dbc-4171-436a-9e27-9b2d0d0dc6c0)

closes #28 