### PR TITLE
Updated symbols list

### DIFF
--- a/_data/symbols_list.yml
+++ b/_data/symbols_list.yml
@@ -1,7 +1,7 @@
 ---
 - unicodemath:
   - forall
-  - __{AA}
+  - '"P{AA}"'
   asciimath:
   - forall
   - AA
@@ -9,17 +9,17 @@
   - "&#x2200;"
   latex:
   - forall
-  - __{AA}
+  - "\\text{P[AA]}"
   omml:
   - "&#x2200;"
   html:
   - "&#x2200;"
 - unicodemath:
-  - __{sinewave}
-  - __{AC}
+  - '"P{sinewave}"'
+  - '"P{AC}"'
   asciimath:
-  - __{sinewave}
-  - __{AC}
+  - '"P{sinewave}"'
+  - '"P{AC}"'
   mathml:
   - "&#x223f;"
   latex:
@@ -30,9 +30,9 @@
   html:
   - "&#x223f;"
 - unicodemath:
-  - __{accurrent}
+  - '"P{accurrent}"'
   asciimath:
-  - __{accurrent}
+  - '"P{accurrent}"'
   mathml:
   - "&#x23e6;"
   latex:
@@ -42,9 +42,9 @@
   html:
   - "&#x23e6;"
 - unicodemath:
-  - __{acidfree}
+  - '"P{acidfree}"'
   asciimath:
-  - __{acidfree}
+  - '"P{acidfree}"'
   mathml:
   - "&#x267e;"
   latex:
@@ -54,9 +54,9 @@
   html:
   - "&#x267e;"
 - unicodemath:
-  - __{acute}
+  - '"P{acute}"'
   asciimath:
-  - __{acute}
+  - '"P{acute}"'
   mathml:
   - "&#x301;"
   latex:
@@ -66,9 +66,9 @@
   html:
   - "&#x301;"
 - unicodemath:
-  - __{acwcirclearrow}
+  - '"P{acwcirclearrow}"'
   asciimath:
-  - __{acwcirclearrow}
+  - '"P{acwcirclearrow}"'
   mathml:
   - "&#x2940;"
   latex:
@@ -78,9 +78,9 @@
   html:
   - "&#x2940;"
 - unicodemath:
-  - __{acwgapcirclearrow}
+  - '"P{acwgapcirclearrow}"'
   asciimath:
-  - __{acwgapcirclearrow}
+  - '"P{acwgapcirclearrow}"'
   mathml:
   - "&#x27f2;"
   latex:
@@ -90,9 +90,9 @@
   html:
   - "&#x27f2;"
 - unicodemath:
-  - __{acwleftarcarrow}
+  - '"P{acwleftarcarrow}"'
   asciimath:
-  - __{acwleftarcarrow}
+  - '"P{acwleftarcarrow}"'
   mathml:
   - "&#x2939;"
   latex:
@@ -102,9 +102,9 @@
   html:
   - "&#x2939;"
 - unicodemath:
-  - __{acwoverarcarrow}
+  - '"P{acwoverarcarrow}"'
   asciimath:
-  - __{acwoverarcarrow}
+  - '"P{acwoverarcarrow}"'
   mathml:
   - "&#x293a;"
   latex:
@@ -114,9 +114,9 @@
   html:
   - "&#x293a;"
 - unicodemath:
-  - __{acwunderarcarrow}
+  - '"P{acwunderarcarrow}"'
   asciimath:
-  - __{acwunderarcarrow}
+  - '"P{acwunderarcarrow}"'
   mathml:
   - "&#x293b;"
   latex:
@@ -139,10 +139,10 @@
   - "&#x2135;"
 - unicodemath:
   - alpha
-  - __{upalpha}
+  - '"P{upalpha}"'
   asciimath:
   - alpha
-  - __{upalpha}
+  - '"P{upalpha}"'
   mathml:
   - "&#x3b1;"
   latex:
@@ -153,9 +153,9 @@
   html:
   - "&#x3b1;"
 - unicodemath:
-  - __{amalg}
+  - '"P{amalg}"'
   asciimath:
-  - __{amalg}
+  - '"P{amalg}"'
   mathml:
   - "&#x2a3f;"
   latex:
@@ -165,11 +165,11 @@
   html:
   - "&#x2a3f;"
 - unicodemath:
-  - __{&}
-  - __{ampersand}
+  - '"P{&}"'
+  - '"P{ampersand}"'
   asciimath:
   - "&"
-  - __{ampersand}
+  - '"P{ampersand}"'
   mathml:
   - "&#x26;"
   latex:
@@ -180,9 +180,9 @@
   html:
   - "&#x26;"
 - unicodemath:
-  - __{anchor}
+  - '"P{anchor}"'
   asciimath:
-  - __{anchor}
+  - '"P{anchor}"'
   mathml:
   - "&#x2693;"
   latex:
@@ -192,9 +192,9 @@
   html:
   - "&#x2693;"
 - unicodemath:
-  - __{angdnr}
+  - '"P{angdnr}"'
   asciimath:
-  - __{angdnr}
+  - '"P{angdnr}"'
   mathml:
   - "&#x299f;"
   latex:
@@ -206,25 +206,25 @@
 - unicodemath:
   - rightangle
   - angle
-  - __{/_}
+  - '"P{/_}"'
   asciimath:
   - angle
   - "/_"
-  - __{rightangle}
+  - '"P{rightangle}"'
   mathml:
   - "&#x2220;"
   latex:
   - angle
-  - __{rightangle}
-  - __{/_}
+  - "\\text{P[rightangle]}"
+  - "\\text{P[/_]}"
   omml:
   - "&#x2220;"
   html:
   - "&#x2220;"
 - unicodemath:
-  - __{angles}
+  - '"P{angles}"'
   asciimath:
-  - __{angles}
+  - '"P{angles}"'
   mathml:
   - "&#x299e;"
   latex:
@@ -234,9 +234,9 @@
   html:
   - "&#x299e;"
 - unicodemath:
-  - __{angleubar}
+  - '"P{angleubar}"'
   asciimath:
-  - __{angleubar}
+  - '"P{angleubar}"'
   mathml:
   - "&#x29a4;"
   latex:
@@ -247,55 +247,55 @@
   - "&#x29a4;"
 - unicodemath:
   - angmsd
-  - __{measuredangle}
+  - '"P{measuredangle}"'
   asciimath:
-  - __{angmsd}
-  - __{measuredangle}
+  - '"P{angmsd}"'
+  - '"P{measuredangle}"'
   mathml:
   - "&#x2221;"
   latex:
   - measuredangle
-  - __{angmsd}
+  - "\\text{P[angmsd]}"
   omml:
   - "&#x2221;"
   html:
   - "&#x2221;"
 - unicodemath:
   - angrtvb
-  - __{measuredrightangle}
+  - '"P{measuredrightangle}"'
   asciimath:
-  - __{angrtvb}
-  - __{measuredrightangle}
+  - '"P{angrtvb}"'
+  - '"P{measuredrightangle}"'
   mathml:
   - "&#x22be;"
   latex:
   - measuredrightangle
-  - __{angrtvb}
+  - "\\text{P[angrtvb]}"
   omml:
   - "&#x22be;"
   html:
   - "&#x22be;"
 - unicodemath:
   - angsph
-  - __{sphericalangle}
+  - '"P{sphericalangle}"'
   asciimath:
-  - __{angsph}
-  - __{sphericalangle}
+  - '"P{angsph}"'
+  - '"P{sphericalangle}"'
   mathml:
   - "&#x2222;"
   latex:
   - sphericalangle
-  - __{angsph}
+  - "\\text{P[angsph]}"
   omml:
   - "&#x2222;"
   html:
   - "&#x2222;"
 - unicodemath:
-  - __{Angstroem}
-  - __{Angstrom}
+  - '"P{Angstroem}"'
+  - '"P{Angstrom}"'
   asciimath:
-  - __{Angstroem}
-  - __{Angstrom}
+  - '"P{Angstroem}"'
+  - '"P{Angstrom}"'
   mathml:
   - "&#x212b;"
   latex:
@@ -306,9 +306,9 @@
   html:
   - "&#x212b;"
 - unicodemath:
-  - __{annuity}
+  - '"P{annuity}"'
   asciimath:
-  - __{annuity}
+  - '"P{annuity}"'
   mathml:
   - "&#x20e7;"
   latex:
@@ -318,9 +318,9 @@
   html:
   - "&#x20e7;"
 - unicodemath:
-  - __{APLboxquestion}
+  - '"P{APLboxquestion}"'
   asciimath:
-  - __{APLboxquestion}
+  - '"P{APLboxquestion}"'
   mathml:
   - "&#x2370;"
   latex:
@@ -330,9 +330,9 @@
   html:
   - "&#x2370;"
 - unicodemath:
-  - __{APLboxupcaret}
+  - '"P{APLboxupcaret}"'
   asciimath:
-  - __{APLboxupcaret}
+  - '"P{APLboxupcaret}"'
   mathml:
   - "&#x2353;"
   latex:
@@ -342,9 +342,9 @@
   html:
   - "&#x2353;"
 - unicodemath:
-  - __{APLcomment}
+  - '"P{APLcomment}"'
   asciimath:
-  - __{APLcomment}
+  - '"P{APLcomment}"'
   mathml:
   - "&#x235d;"
   latex:
@@ -354,9 +354,9 @@
   html:
   - "&#x235d;"
 - unicodemath:
-  - __{APLdownarrowbox}
+  - '"P{APLdownarrowbox}"'
   asciimath:
-  - __{APLdownarrowbox}
+  - '"P{APLdownarrowbox}"'
   mathml:
   - "&#x2357;"
   latex:
@@ -366,9 +366,9 @@
   html:
   - "&#x2357;"
 - unicodemath:
-  - __{APLinput}
+  - '"P{APLinput}"'
   asciimath:
-  - __{APLinput}
+  - '"P{APLinput}"'
   mathml:
   - "&#x235e;"
   latex:
@@ -378,9 +378,9 @@
   html:
   - "&#x235e;"
 - unicodemath:
-  - __{APLinv}
+  - '"P{APLinv}"'
   asciimath:
-  - __{APLinv}
+  - '"P{APLinv}"'
   mathml:
   - "&#x2339;"
   latex:
@@ -390,9 +390,9 @@
   html:
   - "&#x2339;"
 - unicodemath:
-  - __{APLleftarrowbox}
+  - '"P{APLleftarrowbox}"'
   asciimath:
-  - __{APLleftarrowbox}
+  - '"P{APLleftarrowbox}"'
   mathml:
   - "&#x2347;"
   latex:
@@ -402,9 +402,9 @@
   html:
   - "&#x2347;"
 - unicodemath:
-  - __{APLlog}
+  - '"P{APLlog}"'
   asciimath:
-  - __{APLlog}
+  - '"P{APLlog}"'
   mathml:
   - "&#x235f;"
   latex:
@@ -414,9 +414,9 @@
   html:
   - "&#x235f;"
 - unicodemath:
-  - __{APLrightarrowbox}
+  - '"P{APLrightarrowbox}"'
   asciimath:
-  - __{APLrightarrowbox}
+  - '"P{APLrightarrowbox}"'
   mathml:
   - "&#x2348;"
   latex:
@@ -426,9 +426,9 @@
   html:
   - "&#x2348;"
 - unicodemath:
-  - __{APLuparrowbox}
+  - '"P{APLuparrowbox}"'
   asciimath:
-  - __{APLuparrowbox}
+  - '"P{APLuparrowbox}"'
   mathml:
   - "&#x2350;"
   latex:
@@ -439,10 +439,10 @@
   - "&#x2350;"
 - unicodemath:
   - gtrsim
-  - __{apprge}
+  - '"P{apprge}"'
   asciimath:
-  - __{gtrsim}
-  - __{apprge}
+  - '"P{gtrsim}"'
+  - '"P{apprge}"'
   mathml:
   - "&#x2273;"
   latex:
@@ -454,10 +454,10 @@
   - "&#x2273;"
 - unicodemath:
   - lesssim
-  - __{apprle}
+  - '"P{apprle}"'
   asciimath:
-  - __{lesssim}
-  - __{apprle}
+  - '"P{lesssim}"'
+  - '"P{apprle}"'
   mathml:
   - "&#x2272;"
   latex:
@@ -469,7 +469,7 @@
   - "&#x2272;"
 - unicodemath:
   - approx
-  - __{~~}
+  - '"P{~~}"'
   asciimath:
   - approx
   - "~~"
@@ -477,7 +477,7 @@
   - "&#x2248;"
   latex:
   - approx
-  - __{~~}
+  - "\\text{P[~~]}"
   omml:
   - "&#x2248;"
   html:
@@ -485,7 +485,7 @@
 - unicodemath:
   - approxeq
   asciimath:
-  - __{approxeq}
+  - '"P{approxeq}"'
   mathml:
   - "&#x224a;"
   latex:
@@ -495,9 +495,9 @@
   html:
   - "&#x224a;"
 - unicodemath:
-  - __{approxeqq}
+  - '"P{approxeqq}"'
   asciimath:
-  - __{approxeqq}
+  - '"P{approxeqq}"'
   mathml:
   - "&#x2a70;"
   latex:
@@ -507,9 +507,9 @@
   html:
   - "&#x2a70;"
 - unicodemath:
-  - __{approxident}
+  - '"P{approxident}"'
   asciimath:
-  - __{approxident}
+  - '"P{approxident}"'
   mathml:
   - "&#x224b;"
   latex:
@@ -519,9 +519,9 @@
   html:
   - "&#x224b;"
 - unicodemath:
-  - __{aquarius}
+  - '"P{aquarius}"'
   asciimath:
-  - __{aquarius}
+  - '"P{aquarius}"'
   mathml:
   - "&#x2652;"
   latex:
@@ -531,9 +531,9 @@
   html:
   - "&#x2652;"
 - unicodemath:
-  - __{arceq}
+  - '"P{arceq}"'
   asciimath:
-  - __{arceq}
+  - '"P{arceq}"'
   mathml:
   - "&#x2258;"
   latex:
@@ -543,11 +543,11 @@
   html:
   - "&#x2258;"
 - unicodemath:
-  - __{aries}
-  - __{Aries}
+  - '"P{aries}"'
+  - '"P{Aries}"'
   asciimath:
-  - __{aries}
-  - __{Aries}
+  - '"P{aries}"'
+  - '"P{Aries}"'
   mathml:
   - "&#x2648;"
   latex:
@@ -558,9 +558,9 @@
   html:
   - "&#x2648;"
 - unicodemath:
-  - __{arrowbullet}
+  - '"P{arrowbullet}"'
   asciimath:
-  - __{arrowbullet}
+  - '"P{arrowbullet}"'
   mathml:
   - "&#x27a2;"
   latex:
@@ -570,9 +570,9 @@
   html:
   - "&#x27a2;"
 - unicodemath:
-  - __{assert}
+  - '"P{assert}"'
   asciimath:
-  - __{assert}
+  - '"P{assert}"'
   mathml:
   - "&#x22a6;"
   latex:
@@ -583,7 +583,7 @@
   - "&#x22a6;"
 - unicodemath:
   - ast
-  - __{**}
+  - '"P{**}"'
   asciimath:
   - "**"
   - ast
@@ -591,15 +591,15 @@
   - "&#x2217;"
   latex:
   - ast
-  - __{**}
+  - "\\text{P[**]}"
   omml:
   - "&#x2217;"
   html:
   - "&#x2217;"
 - unicodemath:
-  - __{asteq}
+  - '"P{asteq}"'
   asciimath:
-  - __{asteq}
+  - '"P{asteq}"'
   mathml:
   - "&#x2a6e;"
   latex:
@@ -609,9 +609,9 @@
   html:
   - "&#x2a6e;"
 - unicodemath:
-  - __{asteraccent}
+  - '"P{asteraccent}"'
   asciimath:
-  - __{asteraccent}
+  - '"P{asteraccent}"'
   mathml:
   - "&#x20f0;"
   latex:
@@ -623,7 +623,7 @@
 - unicodemath:
   - asymp
   asciimath:
-  - __{asymp}
+  - '"P{asymp}"'
   mathml:
   - "&#x224d;"
   latex:
@@ -633,11 +633,11 @@
   html:
   - "&#x224d;"
 - unicodemath:
-  - __{atsign}
-  - __{@}
+  - '"P{atsign}"'
+  - '"P{@}"'
   asciimath:
-  - __{atsign}
-  - __{@}
+  - '"P{atsign}"'
+  - '"P{@}"'
   mathml:
   - "&#x40;"
   latex:
@@ -648,9 +648,9 @@
   html:
   - "&#x40;"
 - unicodemath:
-  - __{awint}
+  - '"P{awint}"'
   asciimath:
-  - __{awint}
+  - '"P{awint}"'
   mathml:
   - "&#x2a11;"
   latex:
@@ -660,9 +660,9 @@
   html:
   - "&#x2a11;"
 - unicodemath:
-  - __{backcong}
+  - '"P{backcong}"'
   asciimath:
-  - __{backcong}
+  - '"P{backcong}"'
   mathml:
   - "&#x224c;"
   latex:
@@ -672,9 +672,9 @@
   html:
   - "&#x224c;"
 - unicodemath:
-  - __{backdprime}
+  - '"P{backdprime}"'
   asciimath:
-  - __{backdprime}
+  - '"P{backdprime}"'
   mathml:
   - "&#x2036;"
   latex:
@@ -684,11 +684,11 @@
   html:
   - "&#x2036;"
 - unicodemath:
-  - __{upbackepsilon}
-  - __{backepsilon}
+  - '"P{upbackepsilon}"'
+  - '"P{backepsilon}"'
   asciimath:
-  - __{upbackepsilon}
-  - __{backepsilon}
+  - '"P{upbackepsilon}"'
+  - '"P{backepsilon}"'
   mathml:
   - "&#x3f6;"
   latex:
@@ -699,9 +699,9 @@
   html:
   - "&#x3f6;"
 - unicodemath:
-  - __{backprime}
+  - '"P{backprime}"'
   asciimath:
-  - __{backprime}
+  - '"P{backprime}"'
   mathml:
   - "&#x2035;"
   latex:
@@ -713,7 +713,7 @@
 - unicodemath:
   - backsim
   asciimath:
-  - __{backsim}
+  - '"P{backsim}"'
   mathml:
   - "&#x223d;"
   latex:
@@ -725,7 +725,7 @@
 - unicodemath:
   - backsimeq
   asciimath:
-  - __{backsimeq}
+  - '"P{backsimeq}"'
   mathml:
   - "&#x22cd;"
   latex:
@@ -735,8 +735,8 @@
   html:
   - "&#x22cd;"
 - unicodemath:
-  - __{backslash}
-  - __{\}
+  - '"P{backslash}"'
+  - '"P{\}"'
   asciimath:
   - backslash
   - "\\"
@@ -744,15 +744,15 @@
   - "&#x5c;"
   latex:
   - backslash
-  - __{\}
+  - "\\text{P[\\]}"
   omml:
   - "&#x5c;"
   html:
   - "&#x5c;"
 - unicodemath:
-  - __{backtrprime}
+  - '"P{backtrprime}"'
   asciimath:
-  - __{backtrprime}
+  - '"P{backtrprime}"'
   mathml:
   - "&#x2037;"
   latex:
@@ -762,9 +762,9 @@
   html:
   - "&#x2037;"
 - unicodemath:
-  - __{bagmember}
+  - '"P{bagmember}"'
   asciimath:
-  - __{bagmember}
+  - '"P{bagmember}"'
   mathml:
   - "&#x22ff;"
   latex:
@@ -774,9 +774,9 @@
   html:
   - "&#x22ff;"
 - unicodemath:
-  - __{ballotx}
+  - '"P{ballotx}"'
   asciimath:
-  - __{ballotx}
+  - '"P{ballotx}"'
   mathml:
   - "&#x2717;"
   latex:
@@ -798,9 +798,9 @@
   html:
   - "¯"
 - unicodemath:
-  - __{barcap}
+  - '"P{barcap}"'
   asciimath:
-  - __{barcap}
+  - '"P{barcap}"'
   mathml:
   - "&#x2a43;"
   latex:
@@ -810,9 +810,9 @@
   html:
   - "&#x2a43;"
 - unicodemath:
-  - __{barcup}
+  - '"P{barcup}"'
   asciimath:
-  - __{barcup}
+  - '"P{barcup}"'
   mathml:
   - "&#x2a42;"
   latex:
@@ -822,11 +822,11 @@
   html:
   - "&#x2a42;"
 - unicodemath:
-  - __{varisinobar}
-  - __{barin}
+  - '"P{varisinobar}"'
+  - '"P{barin}"'
   asciimath:
-  - __{varisinobar}
-  - __{barin}
+  - '"P{varisinobar}"'
+  - '"P{barin}"'
   mathml:
   - "&#x22f6;"
   latex:
@@ -837,11 +837,11 @@
   html:
   - "&#x22f6;"
 - unicodemath:
-  - __{LeftArrowBar}
-  - __{barleftarrow}
+  - '"P{LeftArrowBar}"'
+  - '"P{barleftarrow}"'
   asciimath:
-  - __{LeftArrowBar}
-  - __{barleftarrow}
+  - '"P{LeftArrowBar}"'
+  - '"P{barleftarrow}"'
   mathml:
   - "&#x21e4;"
   latex:
@@ -852,9 +852,9 @@
   html:
   - "&#x21e4;"
 - unicodemath:
-  - __{barleftarrowrightarrowba}
+  - '"P{barleftarrowrightarrowba}"'
   asciimath:
-  - __{barleftarrowrightarrowba}
+  - '"P{barleftarrowrightarrowba}"'
   mathml:
   - "&#x21b9;"
   latex:
@@ -864,11 +864,11 @@
   html:
   - "&#x21b9;"
 - unicodemath:
-  - __{dashleftharpoondown}
-  - __{barleftharpoon}
+  - '"P{dashleftharpoondown}"'
+  - '"P{barleftharpoon}"'
   asciimath:
-  - __{dashleftharpoondown}
-  - __{barleftharpoon}
+  - '"P{dashleftharpoondown}"'
+  - '"P{barleftharpoon}"'
   mathml:
   - "&#x296b;"
   latex:
@@ -879,9 +879,9 @@
   html:
   - "&#x296b;"
 - unicodemath:
-  - __{barovernorthwestarrow}
+  - '"P{barovernorthwestarrow}"'
   asciimath:
-  - __{barovernorthwestarrow}
+  - '"P{barovernorthwestarrow}"'
   mathml:
   - "&#x21b8;"
   latex:
@@ -891,9 +891,9 @@
   html:
   - "&#x21b8;"
 - unicodemath:
-  - __{barrightarrowdiamond}
+  - '"P{barrightarrowdiamond}"'
   asciimath:
-  - __{barrightarrowdiamond}
+  - '"P{barrightarrowdiamond}"'
   mathml:
   - "&#x2920;"
   latex:
@@ -903,11 +903,11 @@
   html:
   - "&#x2920;"
 - unicodemath:
-  - __{dashrightharpoondown}
-  - __{barrightharpoon}
+  - '"P{dashrightharpoondown}"'
+  - '"P{barrightharpoon}"'
   asciimath:
-  - __{dashrightharpoondown}
-  - __{barrightharpoon}
+  - '"P{dashrightharpoondown}"'
+  - '"P{barrightharpoon}"'
   mathml:
   - "&#x296d;"
   latex:
@@ -918,11 +918,11 @@
   html:
   - "&#x296d;"
 - unicodemath:
-  - __{UpArrowBar}
-  - __{baruparrow}
+  - '"P{UpArrowBar}"'
+  - '"P{baruparrow}"'
   asciimath:
-  - __{UpArrowBar}
-  - __{baruparrow}
+  - '"P{UpArrowBar}"'
+  - '"P{baruparrow}"'
   mathml:
   - "&#x2912;"
   latex:
@@ -933,9 +933,9 @@
   html:
   - "&#x2912;"
 - unicodemath:
-  - __{Barv}
+  - '"P{Barv}"'
   asciimath:
-  - __{Barv}
+  - '"P{Barv}"'
   mathml:
   - "&#x2ae7;"
   latex:
@@ -945,9 +945,9 @@
   html:
   - "&#x2ae7;"
 - unicodemath:
-  - __{barvee}
+  - '"P{barvee}"'
   asciimath:
-  - __{barvee}
+  - '"P{barvee}"'
   mathml:
   - "&#x22bd;"
   latex:
@@ -957,9 +957,9 @@
   html:
   - "&#x22bd;"
 - unicodemath:
-  - __{barwedge}
+  - '"P{barwedge}"'
   asciimath:
-  - __{barwedge}
+  - '"P{barwedge}"'
   mathml:
   - "&#x22bc;"
   latex:
@@ -969,9 +969,9 @@
   html:
   - "&#x22bc;"
 - unicodemath:
-  - __{bbrktbrk}
+  - '"P{bbrktbrk}"'
   asciimath:
-  - __{bbrktbrk}
+  - '"P{bbrktbrk}"'
   mathml:
   - "&#x23b6;"
   latex:
@@ -981,9 +981,9 @@
   html:
   - "&#x23b6;"
 - unicodemath:
-  - __{bdtriplevdash}
+  - '"P{bdtriplevdash}"'
   asciimath:
-  - __{bdtriplevdash}
+  - '"P{bdtriplevdash}"'
   mathml:
   - "&#x2506;"
   latex:
@@ -994,7 +994,7 @@
   - "&#x2506;"
 - unicodemath:
   - because
-  - __{:'}
+  - '"P{:''}"'
   asciimath:
   - because
   - ":'"
@@ -1002,15 +1002,15 @@
   - "&#x2235;"
   latex:
   - because
-  - __{:'}
+  - "\\text{P[:']}"
   omml:
   - "&#x2235;"
   html:
   - "&#x2235;"
 - unicodemath:
-  - __{benzenr}
+  - '"P{benzenr}"'
   asciimath:
-  - __{benzenr}
+  - '"P{benzenr}"'
   mathml:
   - "&#x23e3;"
   latex:
@@ -1022,7 +1022,7 @@
 - unicodemath:
   - beth
   asciimath:
-  - __{beth}
+  - '"P{beth}"'
   mathml:
   - "&#x2136;"
   latex:
@@ -1034,7 +1034,7 @@
 - unicodemath:
   - between
   asciimath:
-  - __{between}
+  - '"P{between}"'
   mathml:
   - "&#x226c;"
   latex:
@@ -1044,9 +1044,9 @@
   html:
   - "&#x226c;"
 - unicodemath:
-  - __{bigblacktriangledown}
+  - '"P{bigblacktriangledown}"'
   asciimath:
-  - __{bigblacktriangledown}
+  - '"P{bigblacktriangledown}"'
   mathml:
   - "&#x25bc;"
   latex:
@@ -1056,9 +1056,9 @@
   html:
   - "&#x25bc;"
 - unicodemath:
-  - __{bigblacktriangleup}
+  - '"P{bigblacktriangleup}"'
   asciimath:
-  - __{bigblacktriangleup}
+  - '"P{bigblacktriangleup}"'
   mathml:
   - "&#x25b2;"
   latex:
@@ -1068,9 +1068,9 @@
   html:
   - "&#x25b2;"
 - unicodemath:
-  - __{bigbot}
+  - '"P{bigbot}"'
   asciimath:
-  - __{bigbot}
+  - '"P{bigbot}"'
   mathml:
   - "&#x27d8;"
   latex:
@@ -1080,9 +1080,9 @@
   html:
   - "&#x27d8;"
 - unicodemath:
-  - __{bigcupdot}
+  - '"P{bigcupdot}"'
   asciimath:
-  - __{bigcupdot}
+  - '"P{bigcupdot}"'
   mathml:
   - "&#x2a03;"
   latex:
@@ -1092,9 +1092,9 @@
   html:
   - "&#x2a03;"
 - unicodemath:
-  - __{biginterleave}
+  - '"P{biginterleave}"'
   asciimath:
-  - __{biginterleave}
+  - '"P{biginterleave}"'
   mathml:
   - "&#x2afc;"
   latex:
@@ -1104,9 +1104,9 @@
   html:
   - "&#x2afc;"
 - unicodemath:
-  - __{bigodot}
+  - '"P{bigodot}"'
   asciimath:
-  - __{bigodot}
+  - '"P{bigodot}"'
   mathml:
   - "&#x2a00;"
   latex:
@@ -1116,9 +1116,9 @@
   html:
   - "&#x2a00;"
 - unicodemath:
-  - __{bigoplus}
+  - '"P{bigoplus}"'
   asciimath:
-  - __{bigoplus}
+  - '"P{bigoplus}"'
   mathml:
   - "&#x2a01;"
   latex:
@@ -1128,9 +1128,9 @@
   html:
   - "&#x2a01;"
 - unicodemath:
-  - __{bigotimes}
+  - '"P{bigotimes}"'
   asciimath:
-  - __{bigotimes}
+  - '"P{bigotimes}"'
   mathml:
   - "&#x2a02;"
   latex:
@@ -1140,9 +1140,9 @@
   html:
   - "&#x2a02;"
 - unicodemath:
-  - __{bigslopedvee}
+  - '"P{bigslopedvee}"'
   asciimath:
-  - __{bigslopedvee}
+  - '"P{bigslopedvee}"'
   mathml:
   - "&#x2a57;"
   latex:
@@ -1152,9 +1152,9 @@
   html:
   - "&#x2a57;"
 - unicodemath:
-  - __{bigslopedwedge}
+  - '"P{bigslopedwedge}"'
   asciimath:
-  - __{bigslopedwedge}
+  - '"P{bigslopedwedge}"'
   mathml:
   - "&#x2a58;"
   latex:
@@ -1164,9 +1164,9 @@
   html:
   - "&#x2a58;"
 - unicodemath:
-  - __{bigsqcap}
+  - '"P{bigsqcap}"'
   asciimath:
-  - __{bigsqcap}
+  - '"P{bigsqcap}"'
   mathml:
   - "&#x2a05;"
   latex:
@@ -1176,9 +1176,9 @@
   html:
   - "&#x2a05;"
 - unicodemath:
-  - __{bigsqcup}
+  - '"P{bigsqcup}"'
   asciimath:
-  - __{bigsqcup}
+  - '"P{bigsqcup}"'
   mathml:
   - "&#x2a06;"
   latex:
@@ -1188,9 +1188,9 @@
   html:
   - "&#x2a06;"
 - unicodemath:
-  - __{bigstar}
+  - '"P{bigstar}"'
   asciimath:
-  - __{bigstar}
+  - '"P{bigstar}"'
   mathml:
   - "&#x2605;"
   latex:
@@ -1200,9 +1200,9 @@
   html:
   - "&#x2605;"
 - unicodemath:
-  - __{bigtalloblong}
+  - '"P{bigtalloblong}"'
   asciimath:
-  - __{bigtalloblong}
+  - '"P{bigtalloblong}"'
   mathml:
   - "&#x2aff;"
   latex:
@@ -1212,9 +1212,9 @@
   html:
   - "&#x2aff;"
 - unicodemath:
-  - __{bigtop}
+  - '"P{bigtop}"'
   asciimath:
-  - __{bigtop}
+  - '"P{bigtop}"'
   mathml:
   - "&#x27d9;"
   latex:
@@ -1224,9 +1224,9 @@
   html:
   - "&#x27d9;"
 - unicodemath:
-  - __{bigtriangledown}
+  - '"P{bigtriangledown}"'
   asciimath:
-  - __{bigtriangledown}
+  - '"P{bigtriangledown}"'
   mathml:
   - "&#x25bd;"
   latex:
@@ -1236,9 +1236,9 @@
   html:
   - "&#x25bd;"
 - unicodemath:
-  - __{bigtriangleleft}
+  - '"P{bigtriangleleft}"'
   asciimath:
-  - __{bigtriangleleft}
+  - '"P{bigtriangleleft}"'
   mathml:
   - "&#x2a1e;"
   latex:
@@ -1249,26 +1249,26 @@
   - "&#x2a1e;"
 - unicodemath:
   - triangle
-  - __{/_\}
-  - __{bigtriangleup}
+  - '"P{/_\}"'
+  - '"P{bigtriangleup}"'
   asciimath:
   - triangle
   - "/_\\"
-  - __{bigtriangleup}
+  - '"P{bigtriangleup}"'
   mathml:
   - "&#x25b3;"
   latex:
   - bigtriangleup
   - triangle
-  - __{/_\}
+  - "\\text{P[/_\\]}"
   omml:
   - "&#x25b3;"
   html:
   - "&#x25b3;"
 - unicodemath:
-  - __{biguplus}
+  - '"P{biguplus}"'
   asciimath:
-  - __{biguplus}
+  - '"P{biguplus}"'
   mathml:
   - "&#x2a04;"
   latex:
@@ -1278,8 +1278,8 @@
   html:
   - "&#x2a04;"
 - unicodemath:
-  - bigwedge
-  - __{^^^}
+  - '"P{bigwedge}"'
+  - '"P{^^^}"'
   asciimath:
   - bigwedge
   - "^^^"
@@ -1287,15 +1287,15 @@
   - "&#x22c0;"
   latex:
   - bigwedge
-  - __{^^^}
+  - "\\text{P[^^^]}"
   omml:
   - "&#x22c0;"
   html:
   - "&#x22c0;"
 - unicodemath:
-  - __{bigwhitestar}
+  - '"P{bigwhitestar}"'
   asciimath:
-  - __{bigwhitestar}
+  - '"P{bigwhitestar}"'
   mathml:
   - "&#x2606;"
   latex:
@@ -1305,27 +1305,27 @@
   html:
   - "&#x2606;"
 - unicodemath:
-  - __{twoheadrightarrowtail}
-  - __{>->>}
-  - __{bij}
+  - '"P{twoheadrightarrowtail}"'
+  - '"P{>->>}"'
+  - '"P{bij}"'
   asciimath:
   - twoheadrightarrowtail
   - ">->>"
-  - __{bij}
+  - '"P{bij}"'
   mathml:
   - "&#x2916;"
   latex:
   - twoheadrightarrowtail
   - bij
-  - __{>->>}
+  - "\\text{P[>->>]}"
   omml:
   - "&#x2916;"
   html:
   - "&#x2916;"
 - unicodemath:
-  - __{biohazard}
+  - '"P{biohazard}"'
   asciimath:
-  - __{biohazard}
+  - '"P{biohazard}"'
   mathml:
   - "&#x2623;"
   latex:
@@ -1335,9 +1335,9 @@
   html:
   - "&#x2623;"
 - unicodemath:
-  - __{blackcircledownarrow}
+  - '"P{blackcircledownarrow}"'
   asciimath:
-  - __{blackcircledownarrow}
+  - '"P{blackcircledownarrow}"'
   mathml:
   - "&#x29ed;"
   latex:
@@ -1347,9 +1347,9 @@
   html:
   - "&#x29ed;"
 - unicodemath:
-  - __{blackcircledrightdot}
+  - '"P{blackcircledrightdot}"'
   asciimath:
-  - __{blackcircledrightdot}
+  - '"P{blackcircledrightdot}"'
   mathml:
   - "&#x2688;"
   latex:
@@ -1359,9 +1359,9 @@
   html:
   - "&#x2688;"
 - unicodemath:
-  - __{blackcircledtwodots}
+  - '"P{blackcircledtwodots}"'
   asciimath:
-  - __{blackcircledtwodots}
+  - '"P{blackcircledtwodots}"'
   mathml:
   - "&#x2689;"
   latex:
@@ -1371,9 +1371,9 @@
   html:
   - "&#x2689;"
 - unicodemath:
-  - __{blackcircleulquadwhite}
+  - '"P{blackcircleulquadwhite}"'
   asciimath:
-  - __{blackcircleulquadwhite}
+  - '"P{blackcircleulquadwhite}"'
   mathml:
   - "&#x25d5;"
   latex:
@@ -1383,9 +1383,9 @@
   html:
   - "&#x25d5;"
 - unicodemath:
-  - __{blackdiamonddownarrow}
+  - '"P{blackdiamonddownarrow}"'
   asciimath:
-  - __{blackdiamonddownarrow}
+  - '"P{blackdiamonddownarrow}"'
   mathml:
   - "&#x29ea;"
   latex:
@@ -1395,9 +1395,9 @@
   html:
   - "&#x29ea;"
 - unicodemath:
-  - __{blackhourglass}
+  - '"P{blackhourglass}"'
   asciimath:
-  - __{blackhourglass}
+  - '"P{blackhourglass}"'
   mathml:
   - "&#x29d7;"
   latex:
@@ -1407,9 +1407,9 @@
   html:
   - "&#x29d7;"
 - unicodemath:
-  - __{blackinwhitediamond}
+  - '"P{blackinwhitediamond}"'
   asciimath:
-  - __{blackinwhitediamond}
+  - '"P{blackinwhitediamond}"'
   mathml:
   - "&#x25c8;"
   latex:
@@ -1419,9 +1419,9 @@
   html:
   - "&#x25c8;"
 - unicodemath:
-  - __{blackinwhitesquare}
+  - '"P{blackinwhitesquare}"'
   asciimath:
-  - __{blackinwhitesquare}
+  - '"P{blackinwhitesquare}"'
   mathml:
   - "&#x25a3;"
   latex:
@@ -1431,11 +1431,11 @@
   html:
   - "&#x25a3;"
 - unicodemath:
-  - __{mdlgblklozenge}
-  - __{blacklozenge}
+  - '"P{mdlgblklozenge}"'
+  - '"P{blacklozenge}"'
   asciimath:
-  - __{mdlgblklozenge}
-  - __{blacklozenge}
+  - '"P{mdlgblklozenge}"'
+  - '"P{blacklozenge}"'
   mathml:
   - "&#x29eb;"
   latex:
@@ -1446,9 +1446,9 @@
   html:
   - "&#x29eb;"
 - unicodemath:
-  - __{blackpointerleft}
+  - '"P{blackpointerleft}"'
   asciimath:
-  - __{blackpointerleft}
+  - '"P{blackpointerleft}"'
   mathml:
   - "&#x25c4;"
   latex:
@@ -1458,9 +1458,9 @@
   html:
   - "&#x25c4;"
 - unicodemath:
-  - __{blackpointerright}
+  - '"P{blackpointerright}"'
   asciimath:
-  - __{blackpointerright}
+  - '"P{blackpointerright}"'
   mathml:
   - "&#x25ba;"
   latex:
@@ -1470,11 +1470,11 @@
   html:
   - "&#x25ba;"
 - unicodemath:
-  - __{invsmileface}
-  - __{blacksmiley}
+  - '"P{invsmileface}"'
+  - '"P{blacksmiley}"'
   asciimath:
-  - __{invsmileface}
-  - __{blacksmiley}
+  - '"P{invsmileface}"'
+  - '"P{blacksmiley}"'
   mathml:
   - "&#x263b;"
   latex:
@@ -1485,11 +1485,11 @@
   html:
   - "&#x263b;"
 - unicodemath:
-  - __{blacktriangleup}
-  - __{blacktriangle}
+  - '"P{blacktriangleup}"'
+  - '"P{blacktriangle}"'
   asciimath:
-  - __{blacktriangleup}
-  - __{blacktriangle}
+  - '"P{blacktriangleup}"'
+  - '"P{blacktriangle}"'
   mathml:
   - "&#x25b4;"
   latex:
@@ -1500,9 +1500,9 @@
   html:
   - "&#x25b4;"
 - unicodemath:
-  - __{blacktriangledown}
+  - '"P{blacktriangledown}"'
   asciimath:
-  - __{blacktriangledown}
+  - '"P{blacktriangledown}"'
   mathml:
   - "&#x25be;"
   latex:
@@ -1512,9 +1512,9 @@
   html:
   - "&#x25be;"
 - unicodemath:
-  - __{blkhorzoval}
+  - '"P{blkhorzoval}"'
   asciimath:
-  - __{blkhorzoval}
+  - '"P{blkhorzoval}"'
   mathml:
   - "&#x2b2c;"
   latex:
@@ -1524,9 +1524,9 @@
   html:
   - "&#x2b2c;"
 - unicodemath:
-  - __{blkvertoval}
+  - '"P{blkvertoval}"'
   asciimath:
-  - __{blkvertoval}
+  - '"P{blkvertoval}"'
   mathml:
   - "&#x2b2e;"
   latex:
@@ -1536,9 +1536,9 @@
   html:
   - "&#x2b2e;"
 - unicodemath:
-  - __{blockfull}
+  - '"P{blockfull}"'
   asciimath:
-  - __{blockfull}
+  - '"P{blockfull}"'
   mathml:
   - "&#x2588;"
   latex:
@@ -1548,9 +1548,9 @@
   html:
   - "&#x2588;"
 - unicodemath:
-  - __{blockhalfshaded}
+  - '"P{blockhalfshaded}"'
   asciimath:
-  - __{blockhalfshaded}
+  - '"P{blockhalfshaded}"'
   mathml:
   - "&#x2592;"
   latex:
@@ -1560,9 +1560,9 @@
   html:
   - "&#x2592;"
 - unicodemath:
-  - __{blocklefthalf}
+  - '"P{blocklefthalf}"'
   asciimath:
-  - __{blocklefthalf}
+  - '"P{blocklefthalf}"'
   mathml:
   - "&#x258c;"
   latex:
@@ -1572,9 +1572,9 @@
   html:
   - "&#x258c;"
 - unicodemath:
-  - __{blocklowhalf}
+  - '"P{blocklowhalf}"'
   asciimath:
-  - __{blocklowhalf}
+  - '"P{blocklowhalf}"'
   mathml:
   - "&#x2584;"
   latex:
@@ -1584,9 +1584,9 @@
   html:
   - "&#x2584;"
 - unicodemath:
-  - __{blockqtrshaded}
+  - '"P{blockqtrshaded}"'
   asciimath:
-  - __{blockqtrshaded}
+  - '"P{blockqtrshaded}"'
   mathml:
   - "&#x2591;"
   latex:
@@ -1596,9 +1596,9 @@
   html:
   - "&#x2591;"
 - unicodemath:
-  - __{blockrighthalf}
+  - '"P{blockrighthalf}"'
   asciimath:
-  - __{blockrighthalf}
+  - '"P{blockrighthalf}"'
   mathml:
   - "&#x2590;"
   latex:
@@ -1608,9 +1608,9 @@
   html:
   - "&#x2590;"
 - unicodemath:
-  - __{blockthreeqtrshaded}
+  - '"P{blockthreeqtrshaded}"'
   asciimath:
-  - __{blockthreeqtrshaded}
+  - '"P{blockthreeqtrshaded}"'
   mathml:
   - "&#x2593;"
   latex:
@@ -1620,9 +1620,9 @@
   html:
   - "&#x2593;"
 - unicodemath:
-  - __{blockuphalf}
+  - '"P{blockuphalf}"'
   asciimath:
-  - __{blockuphalf}
+  - '"P{blockuphalf}"'
   mathml:
   - "&#x2580;"
   latex:
@@ -1632,9 +1632,9 @@
   html:
   - "&#x2580;"
 - unicodemath:
-  - __{bNot}
+  - '"P{bNot}"'
   asciimath:
-  - __{bNot}
+  - '"P{bNot}"'
   mathml:
   - "&#x2aed;"
   latex:
@@ -1644,13 +1644,13 @@
   html:
   - "&#x2aed;"
 - unicodemath:
-  - __{Vbar}
-  - __{Perp}
-  - __{Bot}
+  - '"P{Vbar}"'
+  - '"P{Perp}"'
+  - '"P{Bot}"'
   asciimath:
-  - __{Vbar}
-  - __{Perp}
-  - __{Bot}
+  - '"P{Vbar}"'
+  - '"P{Perp}"'
+  - '"P{Bot}"'
   mathml:
   - "&#x2aeb;"
   latex:
@@ -1662,9 +1662,9 @@
   html:
   - "&#x2aeb;"
 - unicodemath:
-  - __{botsemicircle}
+  - '"P{botsemicircle}"'
   asciimath:
-  - __{botsemicircle}
+  - '"P{botsemicircle}"'
   mathml:
   - "&#x25e1;"
   latex:
@@ -1675,44 +1675,44 @@
   - "&#x25e1;"
 - unicodemath:
   - bowtie
-  - __{|><|}
-  - __{lrtimes}
+  - '"P{|><|}"'
+  - '"P{lrtimes}"'
   asciimath:
   - bowtie
   - "|><|"
-  - __{lrtimes}
+  - '"P{lrtimes}"'
   mathml:
   - "&#x22c8;"
   latex:
   - lrtimes
   - bowtie
-  - __{|><|}
+  - "\\text{P[|><|]}"
   omml:
   - "&#x22c8;"
   html:
   - "&#x22c8;"
 - unicodemath:
   - box
-  - __{square}
-  - __{mdlgwhtsquare}
+  - '"P{square}"'
+  - '"P{mdlgwhtsquare}"'
   asciimath:
   - square
-  - __{box}
-  - __{mdlgwhtsquare}
+  - '"P{box}"'
+  - '"P{mdlgwhtsquare}"'
   mathml:
   - "&#x25a1;"
   latex:
   - mdlgwhtsquare
-  - __{box}
-  - __{square}
+  - "\\text{P[box]}"
+  - "\\text{P[square]}"
   omml:
   - "&#x25a1;"
   html:
   - "&#x25a1;"
 - unicodemath:
-  - __{boxast}
+  - '"P{boxast}"'
   asciimath:
-  - __{boxast}
+  - '"P{boxast}"'
   mathml:
   - "&#x29c6;"
   latex:
@@ -1722,9 +1722,9 @@
   html:
   - "&#x29c6;"
 - unicodemath:
-  - __{boxbar}
+  - '"P{boxbar}"'
   asciimath:
-  - __{boxbar}
+  - '"P{boxbar}"'
   mathml:
   - "&#x25eb;"
   latex:
@@ -1734,9 +1734,9 @@
   html:
   - "&#x25eb;"
 - unicodemath:
-  - __{boxbox}
+  - '"P{boxbox}"'
   asciimath:
-  - __{boxbox}
+  - '"P{boxbox}"'
   mathml:
   - "&#x29c8;"
   latex:
@@ -1746,9 +1746,9 @@
   html:
   - "&#x29c8;"
 - unicodemath:
-  - __{boxbslash}
+  - '"P{boxbslash}"'
   asciimath:
-  - __{boxbslash}
+  - '"P{boxbslash}"'
   mathml:
   - "&#x29c5;"
   latex:
@@ -1758,9 +1758,9 @@
   html:
   - "&#x29c5;"
 - unicodemath:
-  - __{boxcircle}
+  - '"P{boxcircle}"'
   asciimath:
-  - __{boxcircle}
+  - '"P{boxcircle}"'
   mathml:
   - "&#x29c7;"
   latex:
@@ -1770,11 +1770,11 @@
   html:
   - "&#x29c7;"
 - unicodemath:
-  - __{boxslash}
-  - __{boxdiag}
+  - '"P{boxslash}"'
+  - '"P{boxdiag}"'
   asciimath:
-  - __{boxslash}
-  - __{boxdiag}
+  - '"P{boxslash}"'
+  - '"P{boxdiag}"'
   mathml:
   - "&#x29c4;"
   latex:
@@ -1787,7 +1787,7 @@
 - unicodemath:
   - boxdot
   asciimath:
-  - __{boxdot}
+  - '"P{boxdot}"'
   mathml:
   - "&#x22a1;"
   latex:
@@ -1799,7 +1799,7 @@
 - unicodemath:
   - boxminus
   asciimath:
-  - __{boxminus}
+  - '"P{boxminus}"'
   mathml:
   - "&#x229f;"
   latex:
@@ -1809,9 +1809,9 @@
   html:
   - "&#x229f;"
 - unicodemath:
-  - __{boxonbox}
+  - '"P{boxonbox}"'
   asciimath:
-  - __{boxonbox}
+  - '"P{boxonbox}"'
   mathml:
   - "&#x29c9;"
   latex:
@@ -1823,7 +1823,7 @@
 - unicodemath:
   - boxplus
   asciimath:
-  - __{boxplus}
+  - '"P{boxplus}"'
   mathml:
   - "&#x229e;"
   latex:
@@ -1835,7 +1835,7 @@
 - unicodemath:
   - boxtimes
   asciimath:
-  - __{boxtimes}
+  - '"P{boxtimes}"'
   mathml:
   - "&#x22a0;"
   latex:
@@ -1845,9 +1845,9 @@
   html:
   - "&#x22a0;"
 - unicodemath:
-  - __{breve}
+  - '"P{breve}"'
   asciimath:
-  - __{breve}
+  - '"P{breve}"'
   mathml:
   - "&#x306;"
   latex:
@@ -1857,9 +1857,9 @@
   html:
   - "&#x306;"
 - unicodemath:
-  - __{bsimilarleftarrow}
+  - '"P{bsimilarleftarrow}"'
   asciimath:
-  - __{bsimilarleftarrow}
+  - '"P{bsimilarleftarrow}"'
   mathml:
   - "&#x2b41;"
   latex:
@@ -1869,9 +1869,9 @@
   html:
   - "&#x2b41;"
 - unicodemath:
-  - __{bsimilarrightarrow}
+  - '"P{bsimilarrightarrow}"'
   asciimath:
-  - __{bsimilarrightarrow}
+  - '"P{bsimilarrightarrow}"'
   mathml:
   - "&#x2b47;"
   latex:
@@ -1881,9 +1881,9 @@
   html:
   - "&#x2b47;"
 - unicodemath:
-  - __{bsolhsub}
+  - '"P{bsolhsub}"'
   asciimath:
-  - __{bsolhsub}
+  - '"P{bsolhsub}"'
   mathml:
   - "&#x27c8;"
   latex:
@@ -1893,9 +1893,9 @@
   html:
   - "&#x27c8;"
 - unicodemath:
-  - __{btimes}
+  - '"P{btimes}"'
   asciimath:
-  - __{btimes}
+  - '"P{btimes}"'
   mathml:
   - "&#x2a32;"
   latex:
@@ -1906,23 +1906,23 @@
   - "&#x2a32;"
 - unicodemath:
   - bullet
-  - __{vysmblkcircle}
+  - '"P{vysmblkcircle}"'
   asciimath:
-  - __{bullet}
-  - __{vysmblkcircle}
+  - '"P{bullet}"'
+  - '"P{vysmblkcircle}"'
   mathml:
   - "&#x2219;"
   latex:
   - vysmblkcircle
-  - __{bullet}
+  - "\\text{P[bullet]}"
   omml:
   - "&#x2219;"
   html:
   - "&#x2219;"
 - unicodemath:
-  - __{bullseye}
+  - '"P{bullseye}"'
   asciimath:
-  - __{bullseye}
+  - '"P{bullseye}"'
   mathml:
   - "&#x25ce;"
   latex:
@@ -1934,7 +1934,7 @@
 - unicodemath:
   - bumpeq
   asciimath:
-  - __{bumpeq}
+  - '"P{bumpeq}"'
   mathml:
   - "&#x224f;"
   latex:
@@ -1944,9 +1944,9 @@
   html:
   - "&#x224f;"
 - unicodemath:
-  - __{bumpeqq}
+  - '"P{bumpeqq}"'
   asciimath:
-  - __{bumpeqq}
+  - '"P{bumpeqq}"'
   mathml:
   - "&#x2aae;"
   latex:
@@ -1957,10 +1957,10 @@
   - "&#x2aae;"
 - unicodemath:
   - uplus
-  - __{buni}
+  - '"P{buni}"'
   asciimath:
-  - __{uplus}
-  - __{buni}
+  - '"P{uplus}"'
+  - '"P{buni}"'
   mathml:
   - "&#x228e;"
   latex:
@@ -1971,9 +1971,9 @@
   html:
   - "&#x228e;"
 - unicodemath:
-  - __{cancer}
+  - '"P{cancer}"'
   asciimath:
-  - __{cancer}
+  - '"P{cancer}"'
   mathml:
   - "&#x264b;"
   latex:
@@ -1983,9 +1983,9 @@
   html:
   - "&#x264b;"
 - unicodemath:
-  - __{candra}
+  - '"P{candra}"'
   asciimath:
-  - __{candra}
+  - '"P{candra}"'
   mathml:
   - "&#x310;"
   latex:
@@ -2007,9 +2007,9 @@
   html:
   - "&#x2229;"
 - unicodemath:
-  - __{capbarcup}
+  - '"P{capbarcup}"'
   asciimath:
-  - __{capbarcup}
+  - '"P{capbarcup}"'
   mathml:
   - "&#x2a49;"
   latex:
@@ -2019,9 +2019,9 @@
   html:
   - "&#x2a49;"
 - unicodemath:
-  - __{capdot}
+  - '"P{capdot}"'
   asciimath:
-  - __{capdot}
+  - '"P{capdot}"'
   mathml:
   - "&#x2a40;"
   latex:
@@ -2031,9 +2031,9 @@
   html:
   - "&#x2a40;"
 - unicodemath:
-  - __{capovercup}
+  - '"P{capovercup}"'
   asciimath:
-  - __{capovercup}
+  - '"P{capovercup}"'
   mathml:
   - "&#x2a47;"
   latex:
@@ -2043,9 +2043,9 @@
   html:
   - "&#x2a47;"
 - unicodemath:
-  - __{capricornus}
+  - '"P{capricornus}"'
   asciimath:
-  - __{capricornus}
+  - '"P{capricornus}"'
   mathml:
   - "&#x2651;"
   latex:
@@ -2055,9 +2055,9 @@
   html:
   - "&#x2651;"
 - unicodemath:
-  - __{capwedge}
+  - '"P{capwedge}"'
   asciimath:
-  - __{capwedge}
+  - '"P{capwedge}"'
   mathml:
   - "&#x2a44;"
   latex:
@@ -2067,9 +2067,9 @@
   html:
   - "&#x2a44;"
 - unicodemath:
-  - __{caretinsert}
+  - '"P{caretinsert}"'
   asciimath:
-  - __{caretinsert}
+  - '"P{caretinsert}"'
   mathml:
   - "&#x2038;"
   latex:
@@ -2079,9 +2079,9 @@
   html:
   - "&#x2038;"
 - unicodemath:
-  - __{carriagereturn}
+  - '"P{carriagereturn}"'
   asciimath:
-  - __{carriagereturn}
+  - '"P{carriagereturn}"'
   mathml:
   - "&#x21b5;"
   latex:
@@ -2091,11 +2091,11 @@
   html:
   - "&#x21b5;"
 - unicodemath:
-  - __{tieconcat}
-  - __{cat}
+  - '"P{tieconcat}"'
+  - '"P{cat}"'
   asciimath:
-  - __{tieconcat}
-  - __{cat}
+  - '"P{tieconcat}"'
+  - '"P{cat}"'
   mathml:
   - "&#x2040;"
   latex:
@@ -2106,9 +2106,9 @@
   html:
   - "&#x2040;"
 - unicodemath:
-  - __{CC}
+  - '"P{CC}"'
   asciimath:
-  - __{CC}
+  - '"P{CC}"'
   mathml:
   - "&#x2102;"
   latex:
@@ -2118,9 +2118,9 @@
   html:
   - "&#x2102;"
 - unicodemath:
-  - __{ccwundercurvearrow}
+  - '"P{ccwundercurvearrow}"'
   asciimath:
-  - __{ccwundercurvearrow}
+  - '"P{ccwundercurvearrow}"'
   mathml:
   - "&#x293f;"
   latex:
@@ -2131,7 +2131,7 @@
   - "&#x293f;"
 - unicodemath:
   - cdot
-  - __{*}
+  - '"P{*}"'
   asciimath:
   - cdot
   - "*"
@@ -2139,15 +2139,15 @@
   - "&#x22c5;"
   latex:
   - cdot
-  - __{*}
+  - "\\text{P[*]}"
   omml:
   - "&#x22c5;"
   html:
   - "&#x22c5;"
 - unicodemath:
-  - __{cdotp}
+  - '"P{cdotp}"'
   asciimath:
-  - __{cdotp}
+  - '"P{cdotp}"'
   mathml:
   - "&#xb7;"
   latex:
@@ -2157,11 +2157,11 @@
   html:
   - "&#xb7;"
 - unicodemath:
-  - __{cdots}
-  - __{unicodecdots}
+  - '"P{cdots}"'
+  - '"P{unicodecdots}"'
   asciimath:
   - cdots
-  - __{unicodecdots}
+  - '"P{unicodecdots}"'
   mathml:
   - "&#x22ef;"
   latex:
@@ -2172,11 +2172,11 @@
   html:
   - "&#x22ef;"
 - unicodemath:
-  - __{mathcent}
-  - __{cent}
+  - '"P{mathcent}"'
+  - '"P{cent}"'
   asciimath:
-  - __{mathcent}
-  - __{cent}
+  - '"P{mathcent}"'
+  - '"P{cent}"'
   mathml:
   - "&#xa2;"
   latex:
@@ -2187,9 +2187,9 @@
   html:
   - "&#xa2;"
 - unicodemath:
-  - __{check}
+  - '"P{check}"'
   asciimath:
-  - __{check}
+  - '"P{check}"'
   mathml:
   - "&#x30c;"
   latex:
@@ -2199,9 +2199,9 @@
   html:
   - "&#x30c;"
 - unicodemath:
-  - __{CheckedBox}
+  - '"P{CheckedBox}"'
   asciimath:
-  - __{CheckedBox}
+  - '"P{CheckedBox}"'
   mathml:
   - "&#x2611;"
   latex:
@@ -2211,11 +2211,11 @@
   html:
   - "&#x2611;"
 - unicodemath:
-  - __{ballotcheck}
-  - __{checkmark}
+  - '"P{ballotcheck}"'
+  - '"P{checkmark}"'
   asciimath:
-  - __{ballotcheck}
-  - __{checkmark}
+  - '"P{ballotcheck}"'
+  - '"P{checkmark}"'
   mathml:
   - "&#x2713;"
   latex:
@@ -2227,10 +2227,10 @@
   - "&#x2713;"
 - unicodemath:
   - chi
-  - __{upchi}
+  - '"P{upchi}"'
   asciimath:
   - chi
-  - __{upchi}
+  - '"P{upchi}"'
   mathml:
   - "&#x3c7;"
   latex:
@@ -2241,9 +2241,9 @@
   html:
   - "&#x3c7;"
 - unicodemath:
-  - __{cirbot}
+  - '"P{cirbot}"'
   asciimath:
-  - __{cirbot}
+  - '"P{cirbot}"'
   mathml:
   - "&#x27df;"
   latex:
@@ -2255,11 +2255,11 @@
 - unicodemath:
   - circ
   - "@"
-  - __{vysmwhtcircle}
+  - '"P{vysmwhtcircle}"'
   asciimath:
   - circ
   - "@"
-  - __{vysmwhtcircle}
+  - '"P{vysmwhtcircle}"'
   mathml:
   - "&#x2218;"
   latex:
@@ -2273,7 +2273,7 @@
 - unicodemath:
   - circeq
   asciimath:
-  - __{circeq}
+  - '"P{circeq}"'
   mathml:
   - "&#x2257;"
   latex:
@@ -2283,11 +2283,11 @@
   html:
   - "&#x2257;"
 - unicodemath:
-  - __{mdlgblkcircle}
-  - __{CIRCLE}
+  - '"P{mdlgblkcircle}"'
+  - '"P{CIRCLE}"'
   asciimath:
-  - __{mdlgblkcircle}
-  - __{CIRCLE}
+  - '"P{mdlgblkcircle}"'
+  - '"P{CIRCLE}"'
   mathml:
   - "&#x25cf;"
   latex:
@@ -2298,9 +2298,9 @@
   html:
   - "&#x25cf;"
 - unicodemath:
-  - __{circlebottomhalfblack}
+  - '"P{circlebottomhalfblack}"'
   asciimath:
-  - __{circlebottomhalfblack}
+  - '"P{circlebottomhalfblack}"'
   mathml:
   - "&#x25d2;"
   latex:
@@ -2310,9 +2310,9 @@
   html:
   - "&#x25d2;"
 - unicodemath:
-  - __{circledbullet}
+  - '"P{circledbullet}"'
   asciimath:
-  - __{circledbullet}
+  - '"P{circledbullet}"'
   mathml:
   - "&#x29bf;"
   latex:
@@ -2322,11 +2322,11 @@
   html:
   - "&#x29bf;"
 - unicodemath:
-  - __{ogreaterthan}
-  - __{circledgtr}
+  - '"P{ogreaterthan}"'
+  - '"P{circledgtr}"'
   asciimath:
-  - __{ogreaterthan}
-  - __{circledgtr}
+  - '"P{ogreaterthan}"'
+  - '"P{circledgtr}"'
   mathml:
   - "&#x29c1;"
   latex:
@@ -2337,9 +2337,9 @@
   html:
   - "&#x29c1;"
 - unicodemath:
-  - __{circledownarrow}
+  - '"P{circledownarrow}"'
   asciimath:
-  - __{circledownarrow}
+  - '"P{circledownarrow}"'
   mathml:
   - "&#x29ec;"
   latex:
@@ -2349,9 +2349,9 @@
   html:
   - "&#x29ec;"
 - unicodemath:
-  - __{circledparallel}
+  - '"P{circledparallel}"'
   asciimath:
-  - __{circledparallel}
+  - '"P{circledparallel}"'
   mathml:
   - "&#x29b7;"
   latex:
@@ -2361,9 +2361,9 @@
   html:
   - "&#x29b7;"
 - unicodemath:
-  - __{circledR}
+  - '"P{circledR}"'
   asciimath:
-  - __{circledR}
+  - '"P{circledR}"'
   mathml:
   - "&#xae;"
   latex:
@@ -2373,9 +2373,9 @@
   html:
   - "&#xae;"
 - unicodemath:
-  - __{circledrightdot}
+  - '"P{circledrightdot}"'
   asciimath:
-  - __{circledrightdot}
+  - '"P{circledrightdot}"'
   mathml:
   - "&#x2686;"
   latex:
@@ -2385,9 +2385,9 @@
   html:
   - "&#x2686;"
 - unicodemath:
-  - __{circledstar}
+  - '"P{circledstar}"'
   asciimath:
-  - __{circledstar}
+  - '"P{circledstar}"'
   mathml:
   - "&#x272a;"
   latex:
@@ -2397,9 +2397,9 @@
   html:
   - "&#x272a;"
 - unicodemath:
-  - __{circledtwodots}
+  - '"P{circledtwodots}"'
   asciimath:
-  - __{circledtwodots}
+  - '"P{circledtwodots}"'
   mathml:
   - "&#x2687;"
   latex:
@@ -2409,9 +2409,9 @@
   html:
   - "&#x2687;"
 - unicodemath:
-  - __{circledvert}
+  - '"P{circledvert}"'
   asciimath:
-  - __{circledvert}
+  - '"P{circledvert}"'
   mathml:
   - "&#x29b6;"
   latex:
@@ -2421,9 +2421,9 @@
   html:
   - "&#x29b6;"
 - unicodemath:
-  - __{circledwhitebullet}
+  - '"P{circledwhitebullet}"'
   asciimath:
-  - __{circledwhitebullet}
+  - '"P{circledwhitebullet}"'
   mathml:
   - "&#x29be;"
   latex:
@@ -2433,9 +2433,9 @@
   html:
   - "&#x29be;"
 - unicodemath:
-  - __{circlehbar}
+  - '"P{circlehbar}"'
   asciimath:
-  - __{circlehbar}
+  - '"P{circlehbar}"'
   mathml:
   - "&#x29b5;"
   latex:
@@ -2445,9 +2445,9 @@
   html:
   - "&#x29b5;"
 - unicodemath:
-  - __{circlellquad}
+  - '"P{circlellquad}"'
   asciimath:
-  - __{circlellquad}
+  - '"P{circlellquad}"'
   mathml:
   - "&#x25f5;"
   latex:
@@ -2457,9 +2457,9 @@
   html:
   - "&#x25f5;"
 - unicodemath:
-  - __{circlelrquad}
+  - '"P{circlelrquad}"'
   asciimath:
-  - __{circlelrquad}
+  - '"P{circlelrquad}"'
   mathml:
   - "&#x25f6;"
   latex:
@@ -2469,9 +2469,9 @@
   html:
   - "&#x25f6;"
 - unicodemath:
-  - __{circleonleftarrow}
+  - '"P{circleonleftarrow}"'
   asciimath:
-  - __{circleonleftarrow}
+  - '"P{circleonleftarrow}"'
   mathml:
   - "&#x2b30;"
   latex:
@@ -2481,9 +2481,9 @@
   html:
   - "&#x2b30;"
 - unicodemath:
-  - __{circleonrightarrow}
+  - '"P{circleonrightarrow}"'
   asciimath:
-  - __{circleonrightarrow}
+  - '"P{circleonrightarrow}"'
   mathml:
   - "&#x21f4;"
   latex:
@@ -2493,9 +2493,9 @@
   html:
   - "&#x21f4;"
 - unicodemath:
-  - __{circletophalfblack}
+  - '"P{circletophalfblack}"'
   asciimath:
-  - __{circletophalfblack}
+  - '"P{circletophalfblack}"'
   mathml:
   - "&#x25d3;"
   latex:
@@ -2505,9 +2505,9 @@
   html:
   - "&#x25d3;"
 - unicodemath:
-  - __{circleulquad}
+  - '"P{circleulquad}"'
   asciimath:
-  - __{circleulquad}
+  - '"P{circleulquad}"'
   mathml:
   - "&#x25f4;"
   latex:
@@ -2517,9 +2517,9 @@
   html:
   - "&#x25f4;"
 - unicodemath:
-  - __{circleurquad}
+  - '"P{circleurquad}"'
   asciimath:
-  - __{circleurquad}
+  - '"P{circleurquad}"'
   mathml:
   - "&#x25f7;"
   latex:
@@ -2529,9 +2529,9 @@
   html:
   - "&#x25f7;"
 - unicodemath:
-  - __{circleurquadblack}
+  - '"P{circleurquadblack}"'
   asciimath:
-  - __{circleurquadblack}
+  - '"P{circleurquadblack}"'
   mathml:
   - "&#x25d4;"
   latex:
@@ -2541,9 +2541,9 @@
   html:
   - "&#x25d4;"
 - unicodemath:
-  - __{circlevertfill}
+  - '"P{circlevertfill}"'
   asciimath:
-  - __{circlevertfill}
+  - '"P{circlevertfill}"'
   mathml:
   - "&#x25cd;"
   latex:
@@ -2553,9 +2553,9 @@
   html:
   - "&#x25cd;"
 - unicodemath:
-  - __{cirE}
+  - '"P{cirE}"'
   asciimath:
-  - __{cirE}
+  - '"P{cirE}"'
   mathml:
   - "&#x29c3;"
   latex:
@@ -2565,9 +2565,9 @@
   html:
   - "&#x29c3;"
 - unicodemath:
-  - __{cirfnint}
+  - '"P{cirfnint}"'
   asciimath:
-  - __{cirfnint}
+  - '"P{cirfnint}"'
   mathml:
   - "&#x2a10;"
   latex:
@@ -2577,9 +2577,9 @@
   html:
   - "&#x2a10;"
 - unicodemath:
-  - __{cirmid}
+  - '"P{cirmid}"'
   asciimath:
-  - __{cirmid}
+  - '"P{cirmid}"'
   mathml:
   - "&#x2aef;"
   latex:
@@ -2589,9 +2589,9 @@
   html:
   - "&#x2aef;"
 - unicodemath:
-  - __{cirscir}
+  - '"P{cirscir}"'
   asciimath:
-  - __{cirscir}
+  - '"P{cirscir}"'
   mathml:
   - "&#x29c2;"
   latex:
@@ -2601,11 +2601,11 @@
   html:
   - "&#x29c2;"
 - unicodemath:
-  - __{varointclockwise}
-  - __{clockoint}
+  - '"P{varointclockwise}"'
+  - '"P{clockoint}"'
   asciimath:
-  - __{varointclockwise}
-  - __{clockoint}
+  - '"P{varointclockwise}"'
+  - '"P{clockoint}"'
   mathml:
   - "&#x2232;"
   latex:
@@ -2616,9 +2616,9 @@
   html:
   - "&#x2232;"
 - unicodemath:
-  - __{closedvarcap}
+  - '"P{closedvarcap}"'
   asciimath:
-  - __{closedvarcap}
+  - '"P{closedvarcap}"'
   mathml:
   - "&#x2a4d;"
   latex:
@@ -2628,9 +2628,9 @@
   html:
   - "&#x2a4d;"
 - unicodemath:
-  - __{closedvarcup}
+  - '"P{closedvarcup}"'
   asciimath:
-  - __{closedvarcup}
+  - '"P{closedvarcup}"'
   mathml:
   - "&#x2a4c;"
   latex:
@@ -2640,9 +2640,9 @@
   html:
   - "&#x2a4c;"
 - unicodemath:
-  - __{closedvarcupsmashprod}
+  - '"P{closedvarcupsmashprod}"'
   asciimath:
-  - __{closedvarcupsmashprod}
+  - '"P{closedvarcupsmashprod}"'
   mathml:
   - "&#x2a50;"
   latex:
@@ -2652,9 +2652,9 @@
   html:
   - "&#x2a50;"
 - unicodemath:
-  - __{closure}
+  - '"P{closure}"'
   asciimath:
-  - __{closure}
+  - '"P{closure}"'
   mathml:
   - "&#x2050;"
   latex:
@@ -2666,7 +2666,7 @@
 - unicodemath:
   - clubsuit
   asciimath:
-  - __{clubsuit}
+  - '"P{clubsuit}"'
   mathml:
   - "&#x2663;"
   latex:
@@ -2676,11 +2676,11 @@
   html:
   - "&#x2663;"
 - unicodemath:
-  - __{ointctrclockwise}
-  - __{cntclockoint}
+  - '"P{ointctrclockwise}"'
+  - '"P{cntclockoint}"'
   asciimath:
-  - __{ointctrclockwise}
-  - __{cntclockoint}
+  - '"P{ointctrclockwise}"'
+  - '"P{cntclockoint}"'
   mathml:
   - "&#x2233;"
   latex:
@@ -2692,25 +2692,25 @@
   - "&#x2233;"
 - unicodemath:
   - colon
-  - __{mathratio}
+  - '"P{mathratio}"'
   asciimath:
-  - __{colon}
-  - __{mathratio}
+  - '"P{colon}"'
+  - '"P{mathratio}"'
   mathml:
   - "&#x2236;"
   latex:
   - mathratio
-  - __{colon}
+  - "\\text{P[colon]}"
   omml:
   - "&#x2236;"
   html:
   - "&#x2236;"
 - unicodemath:
-  - __{Coloneqq}
-  - __{Coloneq}
+  - '"P{Coloneqq}"'
+  - '"P{Coloneq}"'
   asciimath:
-  - __{Coloneqq}
-  - __{Coloneq}
+  - '"P{Coloneqq}"'
+  - '"P{Coloneq}"'
   mathml:
   - "&#x2a74;"
   latex:
@@ -2722,10 +2722,10 @@
   - "&#x2a74;"
 - unicodemath:
   - ","
-  - __{comma}
+  - '"P{comma}"'
   asciimath:
   - ","
-  - __{comma}
+  - '"P{comma}"'
   mathml:
   - ","
   latex:
@@ -2736,9 +2736,9 @@
   html:
   - ","
 - unicodemath:
-  - __{commaminus}
+  - '"P{commaminus}"'
   asciimath:
-  - __{commaminus}
+  - '"P{commaminus}"'
   mathml:
   - "&#x2a29;"
   latex:
@@ -2748,11 +2748,11 @@
   html:
   - "&#x2a29;"
 - unicodemath:
-  - __{fcmp}
-  - __{comp}
+  - '"P{fcmp}"'
+  - '"P{comp}"'
   asciimath:
-  - __{fcmp}
-  - __{comp}
+  - '"P{fcmp}"'
+  - '"P{comp}"'
   mathml:
   - "&#x2a3e;"
   latex:
@@ -2765,7 +2765,7 @@
 - unicodemath:
   - complement
   asciimath:
-  - __{complement}
+  - '"P{complement}"'
   mathml:
   - "&#x2201;"
   latex:
@@ -2775,9 +2775,9 @@
   html:
   - "&#x2201;"
 - unicodemath:
-  - __{concavediamond}
+  - '"P{concavediamond}"'
   asciimath:
-  - __{concavediamond}
+  - '"P{concavediamond}"'
   mathml:
   - "&#x27e1;"
   latex:
@@ -2787,9 +2787,9 @@
   html:
   - "&#x27e1;"
 - unicodemath:
-  - __{concavediamondtickleft}
+  - '"P{concavediamondtickleft}"'
   asciimath:
-  - __{concavediamondtickleft}
+  - '"P{concavediamondtickleft}"'
   mathml:
   - "&#x27e2;"
   latex:
@@ -2799,9 +2799,9 @@
   html:
   - "&#x27e2;"
 - unicodemath:
-  - __{concavediamondtickright}
+  - '"P{concavediamondtickright}"'
   asciimath:
-  - __{concavediamondtickright}
+  - '"P{concavediamondtickright}"'
   mathml:
   - "&#x27e3;"
   latex:
@@ -2812,7 +2812,7 @@
   - "&#x27e3;"
 - unicodemath:
   - cong
-  - __{~=}
+  - '"P{~=}"'
   asciimath:
   - cong
   - "~="
@@ -2820,15 +2820,15 @@
   - "&#x2245;"
   latex:
   - cong
-  - __{~=}
+  - "\\text{P[~=]}"
   omml:
   - "&#x2245;"
   html:
   - "&#x2245;"
 - unicodemath:
-  - __{congdot}
+  - '"P{congdot}"'
   asciimath:
-  - __{congdot}
+  - '"P{congdot}"'
   mathml:
   - "&#x2a6d;"
   latex:
@@ -2838,9 +2838,9 @@
   html:
   - "&#x2a6d;"
 - unicodemath:
-  - __{conictaper}
+  - '"P{conictaper}"'
   asciimath:
-  - __{conictaper}
+  - '"P{conictaper}"'
   mathml:
   - "&#x2332;"
   latex:
@@ -2850,9 +2850,9 @@
   html:
   - "&#x2332;"
 - unicodemath:
-  - __{conjquant}
+  - '"P{conjquant}"'
   asciimath:
-  - __{conjquant}
+  - '"P{conjquant}"'
   mathml:
   - "&#x2a07;"
   latex:
@@ -2862,9 +2862,9 @@
   html:
   - "&#x2a07;"
 - unicodemath:
-  - __{coprod}
+  - '"P{coprod}"'
   asciimath:
-  - __{coprod}
+  - '"P{coprod}"'
   mathml:
   - "&#x2210;"
   latex:
@@ -2874,9 +2874,9 @@
   html:
   - "&#x2210;"
 - unicodemath:
-  - __{csub}
+  - '"P{csub}"'
   asciimath:
-  - __{csub}
+  - '"P{csub}"'
   mathml:
   - "&#x2acf;"
   latex:
@@ -2886,9 +2886,9 @@
   html:
   - "&#x2acf;"
 - unicodemath:
-  - __{csube}
+  - '"P{csube}"'
   asciimath:
-  - __{csube}
+  - '"P{csube}"'
   mathml:
   - "&#x2ad1;"
   latex:
@@ -2898,9 +2898,9 @@
   html:
   - "&#x2ad1;"
 - unicodemath:
-  - __{csup}
+  - '"P{csup}"'
   asciimath:
-  - __{csup}
+  - '"P{csup}"'
   mathml:
   - "&#x2ad0;"
   latex:
@@ -2910,9 +2910,9 @@
   html:
   - "&#x2ad0;"
 - unicodemath:
-  - __{csupe}
+  - '"P{csupe}"'
   asciimath:
-  - __{csupe}
+  - '"P{csupe}"'
   mathml:
   - "&#x2ad2;"
   latex:
@@ -2922,9 +2922,9 @@
   html:
   - "&#x2ad2;"
 - unicodemath:
-  - __{cuberoot}
+  - '"P{cuberoot}"'
   asciimath:
-  - __{cuberoot}
+  - '"P{cuberoot}"'
   mathml:
   - "&#x221b;"
   latex:
@@ -2936,7 +2936,7 @@
 - unicodemath:
   - Cup
   asciimath:
-  - __{Cup}
+  - '"P{Cup}"'
   mathml:
   - "&#x22d3;"
   latex:
@@ -2946,9 +2946,9 @@
   html:
   - "&#x22d3;"
 - unicodemath:
-  - __{cupbarcap}
+  - '"P{cupbarcap}"'
   asciimath:
-  - __{cupbarcap}
+  - '"P{cupbarcap}"'
   mathml:
   - "&#x2a48;"
   latex:
@@ -2958,9 +2958,9 @@
   html:
   - "&#x2a48;"
 - unicodemath:
-  - __{cupdot}
+  - '"P{cupdot}"'
   asciimath:
-  - __{cupdot}
+  - '"P{cupdot}"'
   mathml:
   - "&#x228d;"
   latex:
@@ -2970,9 +2970,9 @@
   html:
   - "&#x228d;"
 - unicodemath:
-  - __{cupleftarrow}
+  - '"P{cupleftarrow}"'
   asciimath:
-  - __{cupleftarrow}
+  - '"P{cupleftarrow}"'
   mathml:
   - "&#x228c;"
   latex:
@@ -2982,9 +2982,9 @@
   html:
   - "&#x228c;"
 - unicodemath:
-  - __{cupovercap}
+  - '"P{cupovercap}"'
   asciimath:
-  - __{cupovercap}
+  - '"P{cupovercap}"'
   mathml:
   - "&#x2a46;"
   latex:
@@ -2994,9 +2994,9 @@
   html:
   - "&#x2a46;"
 - unicodemath:
-  - __{cupvee}
+  - '"P{cupvee}"'
   asciimath:
-  - __{cupvee}
+  - '"P{cupvee}"'
   mathml:
   - "&#x2a45;"
   latex:
@@ -3008,7 +3008,7 @@
 - unicodemath:
   - curlyeqprec
   asciimath:
-  - __{curlyeqprec}
+  - '"P{curlyeqprec}"'
   mathml:
   - "&#x22de;"
   latex:
@@ -3020,7 +3020,7 @@
 - unicodemath:
   - curlyeqsucc
   asciimath:
-  - __{curlyeqsucc}
+  - '"P{curlyeqsucc}"'
   mathml:
   - "&#x22df;"
   latex:
@@ -3032,7 +3032,7 @@
 - unicodemath:
   - curlyvee
   asciimath:
-  - __{curlyvee}
+  - '"P{curlyvee}"'
   mathml:
   - "&#x22ce;"
   latex:
@@ -3044,7 +3044,7 @@
 - unicodemath:
   - curlywedge
   asciimath:
-  - __{curlywedge}
+  - '"P{curlywedge}"'
   mathml:
   - "&#x22cf;"
   latex:
@@ -3054,9 +3054,9 @@
   html:
   - "&#x22cf;"
 - unicodemath:
-  - __{curvearrowleftplus}
+  - '"P{curvearrowleftplus}"'
   asciimath:
-  - __{curvearrowleftplus}
+  - '"P{curvearrowleftplus}"'
   mathml:
   - "&#x293d;"
   latex:
@@ -3066,9 +3066,9 @@
   html:
   - "&#x293d;"
 - unicodemath:
-  - __{curvearrowright}
+  - '"P{curvearrowright}"'
   asciimath:
-  - __{curvearrowright}
+  - '"P{curvearrowright}"'
   mathml:
   - "&#x21b7;"
   latex:
@@ -3078,9 +3078,9 @@
   html:
   - "&#x21b7;"
 - unicodemath:
-  - __{curvearrowrightminus}
+  - '"P{curvearrowrightminus}"'
   asciimath:
-  - __{curvearrowrightminus}
+  - '"P{curvearrowrightminus}"'
   mathml:
   - "&#x293c;"
   latex:
@@ -3090,9 +3090,9 @@
   html:
   - "&#x293c;"
 - unicodemath:
-  - __{cwcirclearrow}
+  - '"P{cwcirclearrow}"'
   asciimath:
-  - __{cwcirclearrow}
+  - '"P{cwcirclearrow}"'
   mathml:
   - "&#x2941;"
   latex:
@@ -3102,9 +3102,9 @@
   html:
   - "&#x2941;"
 - unicodemath:
-  - __{cwgapcirclearrow}
+  - '"P{cwgapcirclearrow}"'
   asciimath:
-  - __{cwgapcirclearrow}
+  - '"P{cwgapcirclearrow}"'
   mathml:
   - "&#x27f3;"
   latex:
@@ -3114,9 +3114,9 @@
   html:
   - "&#x27f3;"
 - unicodemath:
-  - __{cwrightarcarrow}
+  - '"P{cwrightarcarrow}"'
   asciimath:
-  - __{cwrightarcarrow}
+  - '"P{cwrightarcarrow}"'
   mathml:
   - "&#x2938;"
   latex:
@@ -3126,9 +3126,9 @@
   html:
   - "&#x2938;"
 - unicodemath:
-  - __{cwundercurvearrow}
+  - '"P{cwundercurvearrow}"'
   asciimath:
-  - __{cwundercurvearrow}
+  - '"P{cwundercurvearrow}"'
   mathml:
   - "&#x293e;"
   latex:
@@ -3139,15 +3139,15 @@
   - "&#x293e;"
 - unicodemath:
   - dag
-  - __{dagger}
+  - '"P{dagger}"'
   asciimath:
-  - __{dag}
-  - __{dagger}
+  - '"P{dag}"'
+  - '"P{dagger}"'
   mathml:
   - "&#x2020;"
   latex:
   - dagger
-  - __{dag}
+  - "\\text{P[dag]}"
   omml:
   - "&#x2020;"
   html:
@@ -3155,7 +3155,7 @@
 - unicodemath:
   - daleth
   asciimath:
-  - __{daleth}
+  - '"P{daleth}"'
   mathml:
   - "&#x2138;"
   latex:
@@ -3165,9 +3165,9 @@
   html:
   - "&#x2138;"
 - unicodemath:
-  - __{danger}
+  - '"P{danger}"'
   asciimath:
-  - __{danger}
+  - '"P{danger}"'
   mathml:
   - "&#x2621;"
   latex:
@@ -3178,7 +3178,7 @@
   - "&#x2621;"
 - unicodemath:
   - downarrow
-  - __{darr}
+  - '"P{darr}"'
   asciimath:
   - downarrow
   - darr
@@ -3186,19 +3186,19 @@
   - "&#x2193;"
   latex:
   - downarrow
-  - __{darr}
+  - "\\text{P[darr]}"
   omml:
   - "&#x2193;"
   html:
   - "&#x2193;"
 - unicodemath:
-  - __{dashrightarrow}
-  - __{rightdasharrow}
-  - __{dasharrow}
+  - '"P{dashrightarrow}"'
+  - '"P{rightdasharrow}"'
+  - '"P{dasharrow}"'
   asciimath:
-  - __{dashrightarrow}
-  - __{rightdasharrow}
-  - __{dasharrow}
+  - '"P{dashrightarrow}"'
+  - '"P{rightdasharrow}"'
+  - '"P{dasharrow}"'
   mathml:
   - "&#x21e2;"
   latex:
@@ -3212,19 +3212,19 @@
 - unicodemath:
   - dasharrowright
   asciimath:
-  - __{dasharrowright}
+  - '"P{dasharrowright}"'
   mathml:
   - "&#x21eb;"
   latex:
-  - __{dasharrowright}
+  - "\\text{P[dasharrowright]}"
   omml:
   - "&#x21eb;"
   html:
   - "&#x21eb;"
 - unicodemath:
-  - __{DashV}
+  - '"P{DashV}"'
   asciimath:
-  - __{DashV}
+  - '"P{DashV}"'
   mathml:
   - "&#x2ae5;"
   latex:
@@ -3234,9 +3234,9 @@
   html:
   - "&#x2ae5;"
 - unicodemath:
-  - __{dashVdash}
+  - '"P{dashVdash}"'
   asciimath:
-  - __{dashVdash}
+  - '"P{dashVdash}"'
   mathml:
   - "&#x27db;"
   latex:
@@ -3246,9 +3246,9 @@
   html:
   - "&#x27db;"
 - unicodemath:
-  - __{dbkarow}
+  - '"P{dbkarow}"'
   asciimath:
-  - __{dbkarow}
+  - '"P{dbkarow}"'
   mathml:
   - "&#x290f;"
   latex:
@@ -3259,10 +3259,10 @@
   - "&#x290f;"
 - unicodemath:
   - dd
-  - __{DifferentialD}
+  - '"P{DifferentialD}"'
   asciimath:
-  - __{dd}
-  - __{DifferentialD}
+  - '"P{dd}"'
+  - '"P{DifferentialD}"'
   mathml:
   - "&#x2146;"
   latex:
@@ -3274,23 +3274,23 @@
   - "&#x2146;"
 - unicodemath:
   - ddag
-  - __{ddagger}
+  - '"P{ddagger}"'
   asciimath:
-  - __{ddag}
-  - __{ddagger}
+  - '"P{ddag}"'
+  - '"P{ddagger}"'
   mathml:
   - "&#x2021;"
   latex:
   - ddagger
-  - __{ddag}
+  - "\\text{P[ddag]}"
   omml:
   - "&#x2021;"
   html:
   - "&#x2021;"
 - unicodemath:
-  - __{ddddot}
+  - '"P{ddddot}"'
   asciimath:
-  - __{ddddot}
+  - '"P{ddddot}"'
   mathml:
   - "&#x20dc;"
   latex:
@@ -3300,11 +3300,11 @@
   html:
   - "&#x20dc;"
 - unicodemath:
-  - __{dddot}
-  - __{DDDot}
+  - '"P{dddot}"'
+  - '"P{DDDot}"'
   asciimath:
-  - __{dddot}
-  - __{DDDot}
+  - '"P{dddot}"'
+  - '"P{DDDot}"'
   mathml:
   - "&#x20db;"
   latex:
@@ -3339,9 +3339,9 @@
   html:
   - "&#x22f1;"
 - unicodemath:
-  - __{ddotseq}
+  - '"P{ddotseq}"'
   asciimath:
-  - __{ddotseq}
+  - '"P{ddotseq}"'
   mathml:
   - "&#x2a77;"
   latex:
@@ -3351,9 +3351,9 @@
   html:
   - "&#x2a77;"
 - unicodemath:
-  - __{Ddownarrow}
+  - '"P{Ddownarrow}"'
   asciimath:
-  - __{Ddownarrow}
+  - '"P{Ddownarrow}"'
   mathml:
   - "&#x290b;"
   latex:
@@ -3365,11 +3365,11 @@
 - unicodemath:
   - degc
   asciimath:
-  - __{degc}
+  - '"P{degc}"'
   mathml:
   - "&#x2103;"
   latex:
-  - __{degc}
+  - "\\text{P[degc]}"
   omml:
   - "&#x2103;"
   html:
@@ -3377,11 +3377,11 @@
 - unicodemath:
   - degf
   asciimath:
-  - __{degf}
+  - '"P{degf}"'
   mathml:
   - "&#x2109;"
   latex:
-  - __{degf}
+  - "\\text{P[degf]}"
   omml:
   - "&#x2109;"
   html:
@@ -3389,21 +3389,39 @@
 - unicodemath:
   - degree
   asciimath:
-  - __{degree}
+  - '"P{degree}"'
   mathml:
   - "&#xb0;"
   latex:
-  - __{degree}
+  - "\\text{P[degree]}"
   omml:
   - "&#xb0;"
   html:
   - "&#xb0;"
 - unicodemath:
+  - partial
+  - '"P{del}"'
+  - '"P{partialup}"'
+  asciimath:
+  - partial
+  - del
+  - '"P{partialup}"'
+  mathml:
+  - "&#x2202;"
+  latex:
+  - partialup
+  - partial
+  - "\\text{P[del]}"
+  omml:
+  - "&#x2202;"
+  html:
+  - "&#x2202;"
+- unicodemath:
   - delta
-  - __{updelta}
+  - '"P{updelta}"'
   asciimath:
   - delta
-  - __{updelta}
+  - '"P{updelta}"'
   mathml:
   - "&#x3b4;"
   latex:
@@ -3415,26 +3433,26 @@
   - "&#x3b4;"
 - unicodemath:
   - Deltaeq
-  - __{triangleq}
-  - __{varsdef}
+  - '"P{triangleq}"'
+  - '"P{varsdef}"'
   asciimath:
-  - __{Deltaeq}
-  - __{triangleq}
-  - __{varsdef}
+  - '"P{Deltaeq}"'
+  - '"P{triangleq}"'
+  - '"P{varsdef}"'
   mathml:
   - "&#x225c;"
   latex:
   - triangleq
   - varsdef
-  - __{Deltaeq}
+  - "\\text{P[Deltaeq]}"
   omml:
   - "&#x225c;"
   html:
   - "&#x225c;"
 - unicodemath:
-  - __{diameter}
+  - '"P{diameter}"'
   asciimath:
-  - __{diameter}
+  - '"P{diameter}"'
   mathml:
   - "&#x2300;"
   latex:
@@ -3445,10 +3463,10 @@
   - "&#x2300;"
 - unicodemath:
   - diamond
-  - __{smwhtdiamond}
+  - '"P{smwhtdiamond}"'
   asciimath:
   - diamond
-  - __{smwhtdiamond}
+  - '"P{smwhtdiamond}"'
   mathml:
   - "&#x22c4;"
   latex:
@@ -3459,11 +3477,11 @@
   html:
   - "&#x22c4;"
 - unicodemath:
-  - __{mdlgblkdiamond}
-  - __{Diamondblack}
+  - '"P{mdlgblkdiamond}"'
+  - '"P{Diamondblack}"'
   asciimath:
-  - __{mdlgblkdiamond}
-  - __{Diamondblack}
+  - '"P{mdlgblkdiamond}"'
+  - '"P{Diamondblack}"'
   mathml:
   - "&#x25c6;"
   latex:
@@ -3474,9 +3492,9 @@
   html:
   - "&#x25c6;"
 - unicodemath:
-  - __{diamondbotblack}
+  - '"P{diamondbotblack}"'
   asciimath:
-  - __{diamondbotblack}
+  - '"P{diamondbotblack}"'
   mathml:
   - "&#x2b19;"
   latex:
@@ -3486,11 +3504,11 @@
   html:
   - "&#x2b19;"
 - unicodemath:
-  - __{diamondcdot}
-  - __{Diamonddot}
+  - '"P{diamondcdot}"'
+  - '"P{Diamonddot}"'
   asciimath:
-  - __{diamondcdot}
-  - __{Diamonddot}
+  - '"P{diamondcdot}"'
+  - '"P{Diamonddot}"'
   mathml:
   - "&#x27d0;"
   latex:
@@ -3501,9 +3519,9 @@
   html:
   - "&#x27d0;"
 - unicodemath:
-  - __{diamondleftarrow}
+  - '"P{diamondleftarrow}"'
   asciimath:
-  - __{diamondleftarrow}
+  - '"P{diamondleftarrow}"'
   mathml:
   - "&#x291d;"
   latex:
@@ -3513,9 +3531,9 @@
   html:
   - "&#x291d;"
 - unicodemath:
-  - __{diamondleftarrowbar}
+  - '"P{diamondleftarrowbar}"'
   asciimath:
-  - __{diamondleftarrowbar}
+  - '"P{diamondleftarrowbar}"'
   mathml:
   - "&#x291f;"
   latex:
@@ -3525,9 +3543,9 @@
   html:
   - "&#x291f;"
 - unicodemath:
-  - __{diamondleftblack}
+  - '"P{diamondleftblack}"'
   asciimath:
-  - __{diamondleftblack}
+  - '"P{diamondleftblack}"'
   mathml:
   - "&#x2b16;"
   latex:
@@ -3537,9 +3555,9 @@
   html:
   - "&#x2b16;"
 - unicodemath:
-  - __{diamondrightblack}
+  - '"P{diamondrightblack}"'
   asciimath:
-  - __{diamondrightblack}
+  - '"P{diamondrightblack}"'
   mathml:
   - "&#x2b17;"
   latex:
@@ -3549,9 +3567,9 @@
   html:
   - "&#x2b17;"
 - unicodemath:
-  - __{diamondtopblack}
+  - '"P{diamondtopblack}"'
   asciimath:
-  - __{diamondtopblack}
+  - '"P{diamondtopblack}"'
   mathml:
   - "&#x2b18;"
   latex:
@@ -3561,9 +3579,9 @@
   html:
   - "&#x2b18;"
 - unicodemath:
-  - __{dicei}
+  - '"P{dicei}"'
   asciimath:
-  - __{dicei}
+  - '"P{dicei}"'
   mathml:
   - "&#x2680;"
   latex:
@@ -3573,9 +3591,9 @@
   html:
   - "&#x2680;"
 - unicodemath:
-  - __{diceii}
+  - '"P{diceii}"'
   asciimath:
-  - __{diceii}
+  - '"P{diceii}"'
   mathml:
   - "&#x2681;"
   latex:
@@ -3585,9 +3603,9 @@
   html:
   - "&#x2681;"
 - unicodemath:
-  - __{diceiii}
+  - '"P{diceiii}"'
   asciimath:
-  - __{diceiii}
+  - '"P{diceiii}"'
   mathml:
   - "&#x2682;"
   latex:
@@ -3597,9 +3615,9 @@
   html:
   - "&#x2682;"
 - unicodemath:
-  - __{diceiv}
+  - '"P{diceiv}"'
   asciimath:
-  - __{diceiv}
+  - '"P{diceiv}"'
   mathml:
   - "&#x2683;"
   latex:
@@ -3609,9 +3627,9 @@
   html:
   - "&#x2683;"
 - unicodemath:
-  - __{dicev}
+  - '"P{dicev}"'
   asciimath:
-  - __{dicev}
+  - '"P{dicev}"'
   mathml:
   - "&#x2684;"
   latex:
@@ -3621,9 +3639,9 @@
   html:
   - "&#x2684;"
 - unicodemath:
-  - __{dicevi}
+  - '"P{dicevi}"'
   asciimath:
-  - __{dicevi}
+  - '"P{dicevi}"'
   mathml:
   - "&#x2685;"
   latex:
@@ -3633,11 +3651,11 @@
   html:
   - "&#x2685;"
 - unicodemath:
-  - __{updigamma}
-  - __{digamma}
+  - '"P{updigamma}"'
+  - '"P{digamma}"'
   asciimath:
-  - __{updigamma}
-  - __{digamma}
+  - '"P{updigamma}"'
+  - '"P{digamma}"'
   mathml:
   - "&#x3dd;"
   latex:
@@ -3648,9 +3666,9 @@
   html:
   - "&#x3dd;"
 - unicodemath:
-  - __{dingasterisk}
+  - '"P{dingasterisk}"'
   asciimath:
-  - __{dingasterisk}
+  - '"P{dingasterisk}"'
   mathml:
   - "&#x273d;"
   latex:
@@ -3660,27 +3678,27 @@
   html:
   - "&#x273d;"
 - unicodemath:
-  - bigcap
-  - __{nnn}
-  - __{dint}
+  - '"P{bigcap}"'
+  - '"P{nnn}"'
+  - '"P{dint}"'
   asciimath:
   - bigcap
   - nnn
-  - __{dint}
+  - '"P{dint}"'
   mathml:
   - "&#x22c2;"
   latex:
   - bigcap
   - dint
-  - __{nnn}
+  - "\\text{P[nnn]}"
   omml:
   - "&#x22c2;"
   html:
   - "&#x22c2;"
 - unicodemath:
-  - __{disin}
+  - '"P{disin}"'
   asciimath:
-  - __{disin}
+  - '"P{disin}"'
   mathml:
   - "&#x22f2;"
   latex:
@@ -3690,9 +3708,9 @@
   html:
   - "&#x22f2;"
 - unicodemath:
-  - __{disjquant}
+  - '"P{disjquant}"'
   asciimath:
-  - __{disjquant}
+  - '"P{disjquant}"'
   mathml:
   - "&#x2a08;"
   latex:
@@ -3703,7 +3721,7 @@
   - "&#x2a08;"
 - unicodemath:
   - div
-  - __{-:}
+  - '"P{-:}"'
   asciimath:
   - "-:"
   - div
@@ -3711,7 +3729,7 @@
   - "&#xf7;"
   latex:
   - div
-  - __{-:}
+  - "\\text{P[-:]}"
   omml:
   - "&#xf7;"
   html:
@@ -3719,19 +3737,19 @@
 - unicodemath:
   - divideontimes
   asciimath:
-  - __{divideontimes}
+  - '"P{divideontimes}"'
   mathml:
   - "&#xc7;"
   latex:
-  - __{divideontimes}
+  - "\\text{P[divideontimes]}"
   omml:
   - "&#xc7;"
   html:
   - "&#xc7;"
 - unicodemath:
-  - __{Dot}
+  - '"P{Dot}"'
   asciimath:
-  - __{Dot}
+  - '"P{Dot}"'
   mathml:
   - "&#x307;"
   latex:
@@ -3742,10 +3760,10 @@
   - "&#x307;"
 - unicodemath:
   - Doteq
-  - __{doteqdot}
+  - '"P{doteqdot}"'
   asciimath:
-  - __{Doteq}
-  - __{doteqdot}
+  - '"P{Doteq}"'
+  - '"P{doteqdot}"'
   mathml:
   - "&#x2251;"
   latex:
@@ -3756,9 +3774,9 @@
   html:
   - "&#x2251;"
 - unicodemath:
-  - __{dotequiv}
+  - '"P{dotequiv}"'
   asciimath:
-  - __{dotequiv}
+  - '"P{dotequiv}"'
   mathml:
   - "&#x2a67;"
   latex:
@@ -3770,7 +3788,7 @@
 - unicodemath:
   - dotminus
   asciimath:
-  - __{dotminus}
+  - '"P{dotminus}"'
   mathml:
   - "&#x2238;"
   latex:
@@ -3782,7 +3800,7 @@
 - unicodemath:
   - dotplus
   asciimath:
-  - __{dotplus}
+  - '"P{dotplus}"'
   mathml:
   - "&#x2214;"
   latex:
@@ -3795,27 +3813,27 @@
   - ldots
   - "..."
   - dots
-  - __{unicodeellipsis}
+  - '"P{unicodeellipsis}"'
   asciimath:
   - ldots
   - "..."
-  - __{dots}
-  - __{unicodeellipsis}
+  - '"P{dots}"'
+  - '"P{unicodeellipsis}"'
   mathml:
   - "&#x2026;"
   latex:
   - unicodeellipsis
   - ldots
-  - __{...}
-  - __{dots}
+  - "\\text{P[...]}"
+  - "\\text{P[dots]}"
   omml:
   - "&#x2026;"
   html:
   - "&#x2026;"
 - unicodemath:
-  - __{dotsim}
+  - '"P{dotsim}"'
   asciimath:
-  - __{dotsim}
+  - '"P{dotsim}"'
   mathml:
   - "&#x2a6a;"
   latex:
@@ -3825,9 +3843,9 @@
   html:
   - "&#x2a6a;"
 - unicodemath:
-  - __{dotsminusdots}
+  - '"P{dotsminusdots}"'
   asciimath:
-  - __{dotsminusdots}
+  - '"P{dotsminusdots}"'
   mathml:
   - "&#x223a;"
   latex:
@@ -3837,9 +3855,9 @@
   html:
   - "&#x223a;"
 - unicodemath:
-  - __{dottedcircle}
+  - '"P{dottedcircle}"'
   asciimath:
-  - __{dottedcircle}
+  - '"P{dottedcircle}"'
   mathml:
   - "&#x25cc;"
   latex:
@@ -3849,9 +3867,9 @@
   html:
   - "&#x25cc;"
 - unicodemath:
-  - __{dottedsquare}
+  - '"P{dottedsquare}"'
   asciimath:
-  - __{dottedsquare}
+  - '"P{dottedsquare}"'
   mathml:
   - "&#x2b1a;"
   latex:
@@ -3861,9 +3879,9 @@
   html:
   - "&#x2b1a;"
 - unicodemath:
-  - __{dottimes}
+  - '"P{dottimes}"'
   asciimath:
-  - __{dottimes}
+  - '"P{dottimes}"'
   mathml:
   - "&#x2a30;"
   latex:
@@ -3873,9 +3891,9 @@
   html:
   - "&#x2a30;"
 - unicodemath:
-  - __{doublebarvee}
+  - '"P{doublebarvee}"'
   asciimath:
-  - __{doublebarvee}
+  - '"P{doublebarvee}"'
   mathml:
   - "&#x2a62;"
   latex:
@@ -3885,9 +3903,9 @@
   html:
   - "&#x2a62;"
 - unicodemath:
-  - __{doublebarwedge}
+  - '"P{doublebarwedge}"'
   asciimath:
-  - __{doublebarwedge}
+  - '"P{doublebarwedge}"'
   mathml:
   - "&#x2a5e;"
   latex:
@@ -3897,9 +3915,9 @@
   html:
   - "&#x2a5e;"
 - unicodemath:
-  - __{doubleplus}
+  - '"P{doubleplus}"'
   asciimath:
-  - __{doubleplus}
+  - '"P{doubleplus}"'
   mathml:
   - "&#x29fa;"
   latex:
@@ -3911,7 +3929,7 @@
 - unicodemath:
   - Downarrow
   asciimath:
-  - __{Downarrow}
+  - '"P{Downarrow}"'
   mathml:
   - "&#x21d3;"
   latex:
@@ -3921,11 +3939,11 @@
   html:
   - "&#x21d3;"
 - unicodemath:
-  - __{DownArrowBar}
-  - __{downarrowbar}
+  - '"P{DownArrowBar}"'
+  - '"P{downarrowbar}"'
   asciimath:
-  - __{DownArrowBar}
-  - __{downarrowbar}
+  - '"P{DownArrowBar}"'
+  - '"P{downarrowbar}"'
   mathml:
   - "&#x2913;"
   latex:
@@ -3936,9 +3954,9 @@
   html:
   - "&#x2913;"
 - unicodemath:
-  - __{downarrowbarred}
+  - '"P{downarrowbarred}"'
   asciimath:
-  - __{downarrowbarred}
+  - '"P{downarrowbarred}"'
   mathml:
   - "&#x2908;"
   latex:
@@ -3949,23 +3967,23 @@
   - "&#x2908;"
 - unicodemath:
   - downarrows
-  - __{downdownarrows}
+  - '"P{downdownarrows}"'
   asciimath:
-  - __{downarrows}
-  - __{downdownarrows}
+  - '"P{downarrows}"'
+  - '"P{downdownarrows}"'
   mathml:
   - "&#x21ca;"
   latex:
   - downdownarrows
-  - __{downarrows}
+  - "\\text{P[downarrows]}"
   omml:
   - "&#x21ca;"
   html:
   - "&#x21ca;"
 - unicodemath:
-  - __{downdasharrow}
+  - '"P{downdasharrow}"'
   asciimath:
-  - __{downdasharrow}
+  - '"P{downdasharrow}"'
   mathml:
   - "&#x21e3;"
   latex:
@@ -3975,11 +3993,11 @@
   html:
   - "&#x21e3;"
 - unicodemath:
-  - __{downharpoonsleftright}
-  - __{downdownharpoons}
+  - '"P{downharpoonsleftright}"'
+  - '"P{downdownharpoons}"'
   asciimath:
-  - __{downharpoonsleftright}
-  - __{downdownharpoons}
+  - '"P{downharpoonsleftright}"'
+  - '"P{downdownharpoons}"'
   mathml:
   - "&#x2965;"
   latex:
@@ -3990,9 +4008,9 @@
   html:
   - "&#x2965;"
 - unicodemath:
-  - __{downfishtail}
+  - '"P{downfishtail}"'
   asciimath:
-  - __{downfishtail}
+  - '"P{downfishtail}"'
   mathml:
   - "&#x297f;"
   latex:
@@ -4003,10 +4021,10 @@
   - "&#x297f;"
 - unicodemath:
   - downharpoonleft
-  - __{upharpoonleftdown}
+  - '"P{upharpoonleftdown}"'
   asciimath:
-  - __{downharpoonleft}
-  - __{upharpoonleftdown}
+  - '"P{downharpoonleft}"'
+  - '"P{upharpoonleftdown}"'
   mathml:
   - "&#x21c3;"
   latex:
@@ -4018,10 +4036,10 @@
   - "&#x21c3;"
 - unicodemath:
   - downharpoonright
-  - __{upharpoonrightdown}
+  - '"P{upharpoonrightdown}"'
   asciimath:
-  - __{downharpoonright}
-  - __{upharpoonrightdown}
+  - '"P{downharpoonright}"'
+  - '"P{upharpoonrightdown}"'
   mathml:
   - "&#x21c2;"
   latex:
@@ -4032,11 +4050,11 @@
   html:
   - "&#x21c2;"
 - unicodemath:
-  - __{leftharpoondownbar}
-  - __{DownLeftTeeVector}
+  - '"P{leftharpoondownbar}"'
+  - '"P{DownLeftTeeVector}"'
   asciimath:
-  - __{leftharpoondownbar}
-  - __{DownLeftTeeVector}
+  - '"P{leftharpoondownbar}"'
+  - '"P{DownLeftTeeVector}"'
   mathml:
   - "&#x295e;"
   latex:
@@ -4047,11 +4065,11 @@
   html:
   - "&#x295e;"
 - unicodemath:
-  - __{barleftharpoondown}
-  - __{DownLeftVectorBar}
+  - '"P{barleftharpoondown}"'
+  - '"P{DownLeftVectorBar}"'
   asciimath:
-  - __{barleftharpoondown}
-  - __{DownLeftVectorBar}
+  - '"P{barleftharpoondown}"'
+  - '"P{DownLeftVectorBar}"'
   mathml:
   - "&#x2956;"
   latex:
@@ -4062,9 +4080,9 @@
   html:
   - "&#x2956;"
 - unicodemath:
-  - __{downrightcurvedarrow}
+  - '"P{downrightcurvedarrow}"'
   asciimath:
-  - __{downrightcurvedarrow}
+  - '"P{downrightcurvedarrow}"'
   mathml:
   - "&#x2935;"
   latex:
@@ -4074,11 +4092,11 @@
   html:
   - "&#x2935;"
 - unicodemath:
-  - __{barrightharpoondown}
-  - __{DownRightTeeVector}
+  - '"P{barrightharpoondown}"'
+  - '"P{DownRightTeeVector}"'
   asciimath:
-  - __{barrightharpoondown}
-  - __{DownRightTeeVector}
+  - '"P{barrightharpoondown}"'
+  - '"P{DownRightTeeVector}"'
   mathml:
   - "&#x295f;"
   latex:
@@ -4089,11 +4107,11 @@
   html:
   - "&#x295f;"
 - unicodemath:
-  - __{rightharpoondownbar}
-  - __{DownRightVectorBar}
+  - '"P{rightharpoondownbar}"'
+  - '"P{DownRightVectorBar}"'
   asciimath:
-  - __{rightharpoondownbar}
-  - __{DownRightVectorBar}
+  - '"P{rightharpoondownbar}"'
+  - '"P{DownRightVectorBar}"'
   mathml:
   - "&#x2957;"
   latex:
@@ -4104,9 +4122,9 @@
   html:
   - "&#x2957;"
 - unicodemath:
-  - __{downtriangleleftblack}
+  - '"P{downtriangleleftblack}"'
   asciimath:
-  - __{downtriangleleftblack}
+  - '"P{downtriangleleftblack}"'
   mathml:
   - "&#x29e8;"
   latex:
@@ -4116,9 +4134,9 @@
   html:
   - "&#x29e8;"
 - unicodemath:
-  - __{downtrianglerightblack}
+  - '"P{downtrianglerightblack}"'
   asciimath:
-  - __{downtrianglerightblack}
+  - '"P{downtrianglerightblack}"'
   mathml:
   - "&#x29e9;"
   latex:
@@ -4128,11 +4146,11 @@
   html:
   - "&#x29e9;"
 - unicodemath:
-  - __{downarrowuparrow}
-  - __{downuparrows}
+  - '"P{downarrowuparrow}"'
+  - '"P{downuparrows}"'
   asciimath:
-  - __{downarrowuparrow}
-  - __{downuparrows}
+  - '"P{downarrowuparrow}"'
+  - '"P{downuparrows}"'
   mathml:
   - "&#x21f5;"
   latex:
@@ -4143,13 +4161,13 @@
   html:
   - "&#x21f5;"
 - unicodemath:
-  - __{downupharpoonsleftright}
-  - __{uprevequilibrium}
-  - __{downupharpoons}
+  - '"P{downupharpoonsleftright}"'
+  - '"P{uprevequilibrium}"'
+  - '"P{downupharpoons}"'
   asciimath:
-  - __{downupharpoonsleftright}
-  - __{uprevequilibrium}
-  - __{downupharpoons}
+  - '"P{downupharpoonsleftright}"'
+  - '"P{uprevequilibrium}"'
+  - '"P{downupharpoons}"'
   mathml:
   - "&#x296f;"
   latex:
@@ -4161,9 +4179,9 @@
   html:
   - "&#x296f;"
 - unicodemath:
-  - __{downwhitearrow}
+  - '"P{downwhitearrow}"'
   asciimath:
-  - __{downwhitearrow}
+  - '"P{downwhitearrow}"'
   mathml:
   - "&#x21e9;"
   latex:
@@ -4173,27 +4191,27 @@
   html:
   - "&#x21e9;"
 - unicodemath:
-  - __{''}
-  - __{second}
-  - __{dprime}
+  - '"P{''''}"'
+  - '"P{second}"'
+  - '"P{dprime}"'
   asciimath:
   - "''"
-  - __{second}
-  - __{dprime}
+  - '"P{second}"'
+  - '"P{dprime}"'
   mathml:
   - "&#x2033;"
   latex:
   - second
   - dprime
-  - __{''}
+  - "\\text{P['']}"
   omml:
   - "&#x2033;"
   html:
   - "&#x2033;"
 - unicodemath:
-  - __{draftingarrow}
+  - '"P{draftingarrow}"'
   asciimath:
-  - __{draftingarrow}
+  - '"P{draftingarrow}"'
   mathml:
   - "&#x279b;"
   latex:
@@ -4203,9 +4221,9 @@
   html:
   - "&#x279b;"
 - unicodemath:
-  - __{drbkarow}
+  - '"P{drbkarow}"'
   asciimath:
-  - __{drbkarow}
+  - '"P{drbkarow}"'
   mathml:
   - "&#x2910;"
   latex:
@@ -4215,9 +4233,9 @@
   html:
   - "&#x2910;"
 - unicodemath:
-  - __{droang}
+  - '"P{droang}"'
   asciimath:
-  - __{droang}
+  - '"P{droang}"'
   mathml:
   - "&#x31a;"
   latex:
@@ -4227,9 +4245,9 @@
   html:
   - "&#x31a;"
 - unicodemath:
-  - __{dsol}
+  - '"P{dsol}"'
   asciimath:
-  - __{dsol}
+  - '"P{dsol}"'
   mathml:
   - "&#x29f6;"
   latex:
@@ -4239,11 +4257,11 @@
   html:
   - "&#x29f6;"
 - unicodemath:
-  - __{ndres}
-  - __{dsub}
+  - '"P{ndres}"'
+  - '"P{dsub}"'
   asciimath:
-  - __{ndres}
-  - __{dsub}
+  - '"P{ndres}"'
+  - '"P{dsub}"'
   mathml:
   - "&#x2a64;"
   latex:
@@ -4254,11 +4272,11 @@
   html:
   - "&#x2a64;"
 - unicodemath:
-  - __{multimapboth}
-  - __{dualmap}
+  - '"P{multimapboth}"'
+  - '"P{dualmap}"'
   asciimath:
-  - __{multimapboth}
-  - __{dualmap}
+  - '"P{multimapboth}"'
+  - '"P{dualmap}"'
   mathml:
   - "&#x29df;"
   latex:
@@ -4269,29 +4287,29 @@
   html:
   - "&#x29df;"
 - unicodemath:
-  - bigcup
-  - __{uuu}
-  - __{duni}
+  - '"P{bigcup}"'
+  - '"P{uuu}"'
+  - '"P{duni}"'
   asciimath:
   - bigcup
   - uuu
-  - __{duni}
+  - '"P{duni}"'
   mathml:
   - "&#x22c3;"
   latex:
   - bigcup
   - duni
-  - __{uuu}
+  - "\\text{P[uuu]}"
   omml:
   - "&#x22c3;"
   html:
   - "&#x22c3;"
 - unicodemath:
-  - __{varEarth}
-  - __{earth}
+  - '"P{varEarth}"'
+  - '"P{earth}"'
   asciimath:
-  - __{varEarth}
-  - __{earth}
+  - '"P{varEarth}"'
+  - '"P{earth}"'
   mathml:
   - "&#x2641;"
   latex:
@@ -4302,25 +4320,27 @@
   html:
   - "&#x2641;"
 - unicodemath:
-  - ee
-  - __{EE}
-  - __{exi}
+  - exists
+  - '"P{EE}"'
+  - '"P{exi}"'
   asciimath:
-  - mathbb(e)
-  - __{ee}
+  - exists
+  - EE
+  - '"P{exi}"'
   mathml:
-  - "&#x2147;"
+  - "&#x2203;"
   latex:
-  - "\\mathbb{e}"
-  - __{ee}
+  - exists
+  - exi
+  - "\\text{P[EE]}"
   omml:
-  - "&#x2147;"
+  - "&#x2203;"
   html:
-  - "&#x2147;"
+  - "&#x2203;"
 - unicodemath:
-  - __{egsdot}
+  - '"P{egsdot}"'
   asciimath:
-  - __{egsdot}
+  - '"P{egsdot}"'
   mathml:
   - "&#x2a98;"
   latex:
@@ -4330,9 +4350,9 @@
   html:
   - "&#x2a98;"
 - unicodemath:
-  - __{eighthnote}
+  - '"P{eighthnote}"'
   asciimath:
-  - __{eighthnote}
+  - '"P{eighthnote}"'
   mathml:
   - "&#x266a;"
   latex:
@@ -4342,9 +4362,9 @@
   html:
   - "&#x266a;"
 - unicodemath:
-  - __{elinters}
+  - '"P{elinters}"'
   asciimath:
-  - __{elinters}
+  - '"P{elinters}"'
   mathml:
   - "&#x23e7;"
   latex:
@@ -4356,7 +4376,7 @@
 - unicodemath:
   - ell
   asciimath:
-  - __{ell}
+  - '"P{ell}"'
   mathml:
   - "&#x2113;"
   latex:
@@ -4366,9 +4386,9 @@
   html:
   - "&#x2113;"
 - unicodemath:
-  - __{elsdot}
+  - '"P{elsdot}"'
   asciimath:
-  - __{elsdot}
+  - '"P{elsdot}"'
   mathml:
   - "&#x2a97;"
   latex:
@@ -4379,26 +4399,26 @@
   - "&#x2a97;"
 - unicodemath:
   - emptyset
-  - __{O/}
-  - __{varnothing}
+  - '"P{O/}"'
+  - '"P{varnothing}"'
   asciimath:
   - emptyset
   - O/
-  - __{varnothing}
+  - '"P{varnothing}"'
   mathml:
   - "&#x2205;"
   latex:
   - varnothing
   - emptyset
-  - __{O/}
+  - "\\text{P[O/]}"
   omml:
   - "&#x2205;"
   html:
   - "&#x2205;"
 - unicodemath:
-  - __{emptysetoarr}
+  - '"P{emptysetoarr}"'
   asciimath:
-  - __{emptysetoarr}
+  - '"P{emptysetoarr}"'
   mathml:
   - "&#x29b3;"
   latex:
@@ -4408,9 +4428,9 @@
   html:
   - "&#x29b3;"
 - unicodemath:
-  - __{emptysetoarrl}
+  - '"P{emptysetoarrl}"'
   asciimath:
-  - __{emptysetoarrl}
+  - '"P{emptysetoarrl}"'
   mathml:
   - "&#x29b4;"
   latex:
@@ -4420,9 +4440,9 @@
   html:
   - "&#x29b4;"
 - unicodemath:
-  - __{emptysetobar}
+  - '"P{emptysetobar}"'
   asciimath:
-  - __{emptysetobar}
+  - '"P{emptysetobar}"'
   mathml:
   - "&#x29b1;"
   latex:
@@ -4432,9 +4452,9 @@
   html:
   - "&#x29b1;"
 - unicodemath:
-  - __{emptysetocirc}
+  - '"P{emptysetocirc}"'
   asciimath:
-  - __{emptysetocirc}
+  - '"P{emptysetocirc}"'
   mathml:
   - "&#x29b2;"
   latex:
@@ -4444,9 +4464,9 @@
   html:
   - "&#x29b2;"
 - unicodemath:
-  - __{enclosecircle}
+  - '"P{enclosecircle}"'
   asciimath:
-  - __{enclosecircle}
+  - '"P{enclosecircle}"'
   mathml:
   - "&#x20dd;"
   latex:
@@ -4456,9 +4476,9 @@
   html:
   - "&#x20dd;"
 - unicodemath:
-  - __{enclosediamond}
+  - '"P{enclosediamond}"'
   asciimath:
-  - __{enclosediamond}
+  - '"P{enclosediamond}"'
   mathml:
   - "&#x20df;"
   latex:
@@ -4468,9 +4488,9 @@
   html:
   - "&#x20df;"
 - unicodemath:
-  - __{enclosesquare}
+  - '"P{enclosesquare}"'
   asciimath:
-  - __{enclosesquare}
+  - '"P{enclosesquare}"'
   mathml:
   - "&#x20de;"
   latex:
@@ -4480,9 +4500,9 @@
   html:
   - "&#x20de;"
 - unicodemath:
-  - __{enclosetriangle}
+  - '"P{enclosetriangle}"'
   asciimath:
-  - __{enclosetriangle}
+  - '"P{enclosetriangle}"'
   mathml:
   - "&#x20e4;"
   latex:
@@ -4492,9 +4512,9 @@
   html:
   - "&#x20e4;"
 - unicodemath:
-  - __{enleadertwodots}
+  - '"P{enleadertwodots}"'
   asciimath:
-  - __{enleadertwodots}
+  - '"P{enleadertwodots}"'
   mathml:
   - "&#x2025;"
   latex:
@@ -4505,23 +4525,23 @@
   - "&#x2025;"
 - unicodemath:
   - epar
-  - __{sqsupsetneq}
+  - '"P{sqsupsetneq}"'
   asciimath:
-  - __{epar}
-  - __{sqsupsetneq}
+  - '"P{epar}"'
+  - '"P{sqsupsetneq}"'
   mathml:
   - "&#x22e5;"
   latex:
   - sqsupsetneq
-  - __{epar}
+  - "\\text{P[epar]}"
   omml:
   - "&#x22e5;"
   html:
   - "&#x22e5;"
 - unicodemath:
-  - __{eparsl}
+  - '"P{eparsl}"'
   asciimath:
-  - __{eparsl}
+  - '"P{eparsl}"'
   mathml:
   - "&#x29e3;"
   latex:
@@ -4532,18 +4552,18 @@
   - "&#x29e3;"
 - unicodemath:
   - varepsilon
-  - __{epsilon}
-  - __{upepsilon}
+  - '"P{epsilon}"'
+  - '"P{upepsilon}"'
   asciimath:
   - epsilon
-  - __{varepsilon}
-  - __{upepsilon}
+  - '"P{varepsilon}"'
+  - '"P{upepsilon}"'
   mathml:
   - "&#x3b5;"
   latex:
   - upepsilon
   - epsilon
-  - __{varepsilon}
+  - "\\text{P[varepsilon]}"
   omml:
   - "&#x3b5;"
   html:
@@ -4551,7 +4571,7 @@
 - unicodemath:
   - eqcirc
   asciimath:
-  - __{eqcirc}
+  - '"P{eqcirc}"'
   mathml:
   - "&#x2256;"
   latex:
@@ -4561,11 +4581,11 @@
   html:
   - "&#x2256;"
 - unicodemath:
-  - __{dashcolon}
-  - __{eqcolon}
+  - '"P{dashcolon}"'
+  - '"P{eqcolon}"'
   asciimath:
-  - __{dashcolon}
-  - __{eqcolon}
+  - '"P{dashcolon}"'
+  - '"P{eqcolon}"'
   mathml:
   - "&#x2239;"
   latex:
@@ -4576,9 +4596,9 @@
   html:
   - "&#x2239;"
 - unicodemath:
-  - __{eqdef}
+  - '"P{eqdef}"'
   asciimath:
-  - __{eqdef}
+  - '"P{eqdef}"'
   mathml:
   - "&#x225d;"
   latex:
@@ -4588,9 +4608,9 @@
   html:
   - "&#x225d;"
 - unicodemath:
-  - __{eqdot}
+  - '"P{eqdot}"'
   asciimath:
-  - __{eqdot}
+  - '"P{eqdot}"'
   mathml:
   - "&#x2a66;"
   latex:
@@ -4600,11 +4620,11 @@
   html:
   - "&#x2a66;"
 - unicodemath:
-  - __{Equal}
-  - __{eqeq}
+  - '"P{Equal}"'
+  - '"P{eqeq}"'
   asciimath:
-  - __{Equal}
-  - __{eqeq}
+  - '"P{Equal}"'
+  - '"P{eqeq}"'
   mathml:
   - "&#x2a75;"
   latex:
@@ -4617,7 +4637,7 @@
 - unicodemath:
   - eqgtr
   asciimath:
-  - __{eqgtr}
+  - '"P{eqgtr}"'
   mathml:
   - "&#x22dd;"
   latex:
@@ -4627,9 +4647,9 @@
   html:
   - "&#x22dd;"
 - unicodemath:
-  - __{eqless}
+  - '"P{eqless}"'
   asciimath:
-  - __{eqless}
+  - '"P{eqless}"'
   mathml:
   - "&#x22dc;"
   latex:
@@ -4640,26 +4660,26 @@
   - "&#x22dc;"
 - unicodemath:
   - eqno
-  - __{#}
-  - __{octothorpe}
+  - '"P{#}"'
+  - '"P{octothorpe}"'
   asciimath:
   - "#"
-  - __{eqno}
-  - __{octothorpe}
+  - '"P{eqno}"'
+  - '"P{octothorpe}"'
   mathml:
   - "&#x23;"
   latex:
   - octothorpe
   - "#"
-  - __{eqno}
+  - "\\text{P[eqno]}"
   omml:
   - "&#x23;"
   html:
   - "&#x23;"
 - unicodemath:
-  - __{eqqcolon}
+  - '"P{eqqcolon}"'
   asciimath:
-  - __{eqqcolon}
+  - '"P{eqqcolon}"'
   mathml:
   - "&#x2255;"
   latex:
@@ -4669,9 +4689,9 @@
   html:
   - "&#x2255;"
 - unicodemath:
-  - __{eqqgtr}
+  - '"P{eqqgtr}"'
   asciimath:
-  - __{eqqgtr}
+  - '"P{eqqgtr}"'
   mathml:
   - "&#x2a9a;"
   latex:
@@ -4681,9 +4701,9 @@
   html:
   - "&#x2a9a;"
 - unicodemath:
-  - __{eqqless}
+  - '"P{eqqless}"'
   asciimath:
-  - __{eqqless}
+  - '"P{eqqless}"'
   mathml:
   - "&#x2a99;"
   latex:
@@ -4693,9 +4713,9 @@
   html:
   - "&#x2a99;"
 - unicodemath:
-  - __{eqqplus}
+  - '"P{eqqplus}"'
   asciimath:
-  - __{eqqplus}
+  - '"P{eqqplus}"'
   mathml:
   - "&#x2a71;"
   latex:
@@ -4705,9 +4725,9 @@
   html:
   - "&#x2a71;"
 - unicodemath:
-  - __{eqqsim}
+  - '"P{eqqsim}"'
   asciimath:
-  - __{eqqsim}
+  - '"P{eqqsim}"'
   mathml:
   - "&#x2a73;"
   latex:
@@ -4717,9 +4737,9 @@
   html:
   - "&#x2a73;"
 - unicodemath:
-  - __{eqqslantgtr}
+  - '"P{eqqslantgtr}"'
   asciimath:
-  - __{eqqslantgtr}
+  - '"P{eqqslantgtr}"'
   mathml:
   - "&#x2a9c;"
   latex:
@@ -4729,9 +4749,9 @@
   html:
   - "&#x2a9c;"
 - unicodemath:
-  - __{eqqslantless}
+  - '"P{eqqslantless}"'
   asciimath:
-  - __{eqqslantless}
+  - '"P{eqqslantless}"'
   mathml:
   - "&#x2a9b;"
   latex:
@@ -4741,9 +4761,9 @@
   html:
   - "&#x2a9b;"
 - unicodemath:
-  - __{eqsim}
+  - '"P{eqsim}"'
   asciimath:
-  - __{eqsim}
+  - '"P{eqsim}"'
   mathml:
   - "&#x2242;"
   latex:
@@ -4753,9 +4773,9 @@
   html:
   - "&#x2242;"
 - unicodemath:
-  - __{eqslantgtr}
+  - '"P{eqslantgtr}"'
   asciimath:
-  - __{eqslantgtr}
+  - '"P{eqslantgtr}"'
   mathml:
   - "&#x2a96;"
   latex:
@@ -4765,9 +4785,9 @@
   html:
   - "&#x2a96;"
 - unicodemath:
-  - __{eqslantless}
+  - '"P{eqslantless}"'
   asciimath:
-  - __{eqslantless}
+  - '"P{eqslantless}"'
   mathml:
   - "&#x2a95;"
   latex:
@@ -4778,10 +4798,10 @@
   - "&#x2a95;"
 - unicodemath:
   - "="
-  - __{equal}
+  - '"P{equal}"'
   asciimath:
   - "="
-  - __{equal}
+  - '"P{equal}"'
   mathml:
   - "="
   latex:
@@ -4792,9 +4812,9 @@
   html:
   - "="
 - unicodemath:
-  - __{equalleftarrow}
+  - '"P{equalleftarrow}"'
   asciimath:
-  - __{equalleftarrow}
+  - '"P{equalleftarrow}"'
   mathml:
   - "&#x2b40;"
   latex:
@@ -4804,9 +4824,9 @@
   html:
   - "&#x2b40;"
 - unicodemath:
-  - __{equalrightarrow}
+  - '"P{equalrightarrow}"'
   asciimath:
-  - __{equalrightarrow}
+  - '"P{equalrightarrow}"'
   mathml:
   - "&#x2971;"
   latex:
@@ -4817,7 +4837,7 @@
   - "&#x2971;"
 - unicodemath:
   - equiv
-  - __{-=}
+  - '"P{-=}"'
   asciimath:
   - equiv
   - "-="
@@ -4825,15 +4845,15 @@
   - "&#x2261;"
   latex:
   - equiv
-  - __{-=}
+  - "\\text{P[-=]}"
   omml:
   - "&#x2261;"
   html:
   - "&#x2261;"
 - unicodemath:
-  - __{equivDD}
+  - '"P{equivDD}"'
   asciimath:
-  - __{equivDD}
+  - '"P{equivDD}"'
   mathml:
   - "&#x2a78;"
   latex:
@@ -4843,9 +4863,9 @@
   html:
   - "&#x2a78;"
 - unicodemath:
-  - __{equivVert}
+  - '"P{equivVert}"'
   asciimath:
-  - __{equivVert}
+  - '"P{equivVert}"'
   mathml:
   - "&#x2a68;"
   latex:
@@ -4855,9 +4875,9 @@
   html:
   - "&#x2a68;"
 - unicodemath:
-  - __{equivVvert}
+  - '"P{equivVvert}"'
   asciimath:
-  - __{equivVvert}
+  - '"P{equivVvert}"'
   mathml:
   - "&#x2a69;"
   latex:
@@ -4867,9 +4887,9 @@
   html:
   - "&#x2a69;"
 - unicodemath:
-  - __{eqvparsl}
+  - '"P{eqvparsl}"'
   asciimath:
-  - __{eqvparsl}
+  - '"P{eqvparsl}"'
   mathml:
   - "&#x29e5;"
   latex:
@@ -4879,9 +4899,9 @@
   html:
   - "&#x29e5;"
 - unicodemath:
-  - __{errbarblackcircle}
+  - '"P{errbarblackcircle}"'
   asciimath:
-  - __{errbarblackcircle}
+  - '"P{errbarblackcircle}"'
   mathml:
   - "&#x29f3;"
   latex:
@@ -4891,9 +4911,9 @@
   html:
   - "&#x29f3;"
 - unicodemath:
-  - __{errbarblackdiamond}
+  - '"P{errbarblackdiamond}"'
   asciimath:
-  - __{errbarblackdiamond}
+  - '"P{errbarblackdiamond}"'
   mathml:
   - "&#x29f1;"
   latex:
@@ -4903,9 +4923,9 @@
   html:
   - "&#x29f1;"
 - unicodemath:
-  - __{errbarblacksquare}
+  - '"P{errbarblacksquare}"'
   asciimath:
-  - __{errbarblacksquare}
+  - '"P{errbarblacksquare}"'
   mathml:
   - "&#x29ef;"
   latex:
@@ -4915,9 +4935,9 @@
   html:
   - "&#x29ef;"
 - unicodemath:
-  - __{errbarcircle}
+  - '"P{errbarcircle}"'
   asciimath:
-  - __{errbarcircle}
+  - '"P{errbarcircle}"'
   mathml:
   - "&#x29f2;"
   latex:
@@ -4927,9 +4947,9 @@
   html:
   - "&#x29f2;"
 - unicodemath:
-  - __{errbardiamond}
+  - '"P{errbardiamond}"'
   asciimath:
-  - __{errbardiamond}
+  - '"P{errbardiamond}"'
   mathml:
   - "&#x29f0;"
   latex:
@@ -4939,9 +4959,9 @@
   html:
   - "&#x29f0;"
 - unicodemath:
-  - __{errbarsquare}
+  - '"P{errbarsquare}"'
   asciimath:
-  - __{errbarsquare}
+  - '"P{errbarsquare}"'
   mathml:
   - "&#x29ee;"
   latex:
@@ -4952,10 +4972,10 @@
   - "&#x29ee;"
 - unicodemath:
   - eta
-  - __{upeta}
+  - '"P{upeta}"'
   asciimath:
   - eta
-  - __{upeta}
+  - '"P{upeta}"'
   mathml:
   - "&#x3b7;"
   latex:
@@ -4966,11 +4986,11 @@
   html:
   - "&#x3b7;"
 - unicodemath:
-  - __{matheth}
-  - __{eth}
+  - '"P{matheth}"'
+  - '"P{eth}"'
   asciimath:
-  - __{matheth}
-  - __{eth}
+  - '"P{matheth}"'
+  - '"P{eth}"'
   mathml:
   - "&#xf0;"
   latex:
@@ -4981,11 +5001,11 @@
   html:
   - "&#xf0;"
 - unicodemath:
-  - __{Eulerconst}
-  - __{Euler}
+  - '"P{Eulerconst}"'
+  - '"P{Euler}"'
   asciimath:
-  - __{Eulerconst}
-  - __{Euler}
+  - '"P{Eulerconst}"'
+  - '"P{Euler}"'
   mathml:
   - "&#x2107;"
   latex:
@@ -4996,9 +5016,9 @@
   html:
   - "&#x2107;"
 - unicodemath:
-  - __{euro}
+  - '"P{euro}"'
   asciimath:
-  - __{euro}
+  - '"P{euro}"'
   mathml:
   - "&#x20ac;"
   latex:
@@ -5008,11 +5028,11 @@
   html:
   - "&#x20ac;"
 - unicodemath:
-  - __{!}
-  - __{exclam}
+  - '"P{!}"'
+  - '"P{exclam}"'
   asciimath:
   - "!"
-  - __{exclam}
+  - '"P{exclam}"'
   mathml:
   - "&#x21;"
   latex:
@@ -5024,18 +5044,18 @@
   - "&#x21;"
 - unicodemath:
   - exists
-  - __{EE}
-  - __{exi}
+  - '"P{EE}"'
+  - '"P{exi}"'
   asciimath:
   - exists
   - EE
-  - __{exi}
+  - '"P{exi}"'
   mathml:
   - "&#x2203;"
   latex:
   - exists
   - exi
-  - __{EE}
+  - "\\text{P[EE]}"
   omml:
   - "&#x2203;"
   html:
@@ -5043,17 +5063,17 @@
 - unicodemath:
   - bot
   - perp
-  - __{_|_}
+  - '"P{_|_}"'
   asciimath:
   - _|_
   - bot
-  - __{perp}
+  - '"P{perp}"'
   mathml:
   - "&#x22a5;"
   latex:
   - bot
-  - __{perp}
-  - __{_|_}
+  - "\\text{P[perp]}"
+  - "\\text{P[_|_]}"
   omml:
   - "&#x22a5;"
   html:
@@ -5061,7 +5081,7 @@
 - unicodemath:
   - fallingdotseq
   asciimath:
-  - __{fallingdotseq}
+  - '"P{fallingdotseq}"'
   mathml:
   - "&#x2252;"
   latex:
@@ -5071,9 +5091,9 @@
   html:
   - "&#x2252;"
 - unicodemath:
-  - __{fbowtie}
+  - '"P{fbowtie}"'
   asciimath:
-  - __{fbowtie}
+  - '"P{fbowtie}"'
   mathml:
   - "&#x29d3;"
   latex:
@@ -5083,9 +5103,9 @@
   html:
   - "&#x29d3;"
 - unicodemath:
-  - __{fdiagovnearrow}
+  - '"P{fdiagovnearrow}"'
   asciimath:
-  - __{fdiagovnearrow}
+  - '"P{fdiagovnearrow}"'
   mathml:
   - "&#x292f;"
   latex:
@@ -5095,9 +5115,9 @@
   html:
   - "&#x292f;"
 - unicodemath:
-  - __{fdiagovrdiag}
+  - '"P{fdiagovrdiag}"'
   asciimath:
-  - __{fdiagovrdiag}
+  - '"P{fdiagovrdiag}"'
   mathml:
   - "&#x292c;"
   latex:
@@ -5107,11 +5127,11 @@
   html:
   - "&#x292c;"
 - unicodemath:
-  - __{nVrightarrow}
-  - __{ffun}
+  - '"P{nVrightarrow}"'
+  - '"P{ffun}"'
   asciimath:
-  - __{nVrightarrow}
-  - __{ffun}
+  - '"P{nVrightarrow}"'
+  - '"P{ffun}"'
   mathml:
   - "&#x21fb;"
   latex:
@@ -5122,11 +5142,11 @@
   html:
   - "&#x21fb;"
 - unicodemath:
-  - __{nVrightarrowtail}
-  - __{finj}
+  - '"P{nVrightarrowtail}"'
+  - '"P{finj}"'
   asciimath:
-  - __{nVrightarrowtail}
-  - __{finj}
+  - '"P{nVrightarrowtail}"'
+  - '"P{finj}"'
   mathml:
   - "&#x2915;"
   latex:
@@ -5137,9 +5157,9 @@
   html:
   - "&#x2915;"
 - unicodemath:
-  - __{fint}
+  - '"P{fint}"'
   asciimath:
-  - __{fint}
+  - '"P{fint}"'
   mathml:
   - "&#x2a0f;"
   latex:
@@ -5149,9 +5169,9 @@
   html:
   - "&#x2a0f;"
 - unicodemath:
-  - __{Finv}
+  - '"P{Finv}"'
   asciimath:
-  - __{Finv}
+  - '"P{Finv}"'
   mathml:
   - "&#x2132;"
   latex:
@@ -5161,9 +5181,9 @@
   html:
   - "&#x2132;"
 - unicodemath:
-  - __{fisheye}
+  - '"P{fisheye}"'
   asciimath:
-  - __{fisheye}
+  - '"P{fisheye}"'
   mathml:
   - "&#x25c9;"
   latex:
@@ -5173,9 +5193,9 @@
   html:
   - "&#x25c9;"
 - unicodemath:
-  - __{flat}
+  - '"P{flat}"'
   asciimath:
-  - __{flat}
+  - '"P{flat}"'
   mathml:
   - "&#x266d;"
   latex:
@@ -5185,9 +5205,9 @@
   html:
   - "&#x266d;"
 - unicodemath:
-  - __{fltns}
+  - '"P{fltns}"'
   asciimath:
-  - __{fltns}
+  - '"P{fltns}"'
   mathml:
   - "&#x23e5;"
   latex:
@@ -5198,7 +5218,7 @@
   - "&#x23e5;"
 - unicodemath:
   - forall
-  - __{AA}
+  - '"P{AA}"'
   asciimath:
   - forall
   - AA
@@ -5206,15 +5226,15 @@
   - "&#x2200;"
   latex:
   - forall
-  - __{AA}
+  - "\\text{P[AA]}"
   omml:
   - "&#x2200;"
   html:
   - "&#x2200;"
 - unicodemath:
-  - __{forks}
+  - '"P{forks}"'
   asciimath:
-  - __{forks}
+  - '"P{forks}"'
   mathml:
   - "&#x2adc;"
   latex:
@@ -5224,9 +5244,9 @@
   html:
   - "&#x2adc;"
 - unicodemath:
-  - __{forksnot}
+  - '"P{forksnot}"'
   asciimath:
-  - __{forksnot}
+  - '"P{forksnot}"'
   mathml:
   - "&#x2add;"
   latex:
@@ -5236,9 +5256,9 @@
   html:
   - "&#x2add;"
 - unicodemath:
-  - __{forkv}
+  - '"P{forkv}"'
   asciimath:
-  - __{forkv}
+  - '"P{forkv}"'
   mathml:
   - "&#x2ad9;"
   latex:
@@ -5248,9 +5268,9 @@
   html:
   - "&#x2ad9;"
 - unicodemath:
-  - __{fourthroot}
+  - '"P{fourthroot}"'
   asciimath:
-  - __{fourthroot}
+  - '"P{fourthroot}"'
   mathml:
   - "&#x221c;"
   latex:
@@ -5260,9 +5280,9 @@
   html:
   - "&#x221c;"
 - unicodemath:
-  - __{fourvdots}
+  - '"P{fourvdots}"'
   asciimath:
-  - __{fourvdots}
+  - '"P{fourvdots}"'
   mathml:
   - "&#x2999;"
   latex:
@@ -5272,9 +5292,9 @@
   html:
   - "&#x2999;"
 - unicodemath:
-  - __{fracslash}
+  - '"P{fracslash}"'
   asciimath:
-  - __{fracslash}
+  - '"P{fracslash}"'
   mathml:
   - "&#x2044;"
   latex:
@@ -5296,9 +5316,9 @@
   html:
   - "&#x2322;"
 - unicodemath:
-  - __{fullouterjoin}
+  - '"P{fullouterjoin}"'
   asciimath:
-  - __{fullouterjoin}
+  - '"P{fullouterjoin}"'
   mathml:
   - "&#x27d7;"
   latex:
@@ -5310,19 +5330,19 @@
 - unicodemath:
   - funcapply
   asciimath:
-  - __{funcapply}
+  - '"P{funcapply}"'
   mathml:
   - "&#x2061;"
   latex:
-  - __{funcapply}
+  - "\\text{P[funcapply]}"
   omml:
   - "&#x2061;"
   html:
   - "&#x2061;"
 - unicodemath:
-  - __{Game}
+  - '"P{Game}"'
   asciimath:
-  - __{Game}
+  - '"P{Game}"'
   mathml:
   - "&#x2141;"
   latex:
@@ -5333,10 +5353,10 @@
   - "&#x2141;"
 - unicodemath:
   - gamma
-  - __{upgamma}
+  - '"P{upgamma}"'
   asciimath:
   - gamma
-  - __{upgamma}
+  - '"P{upgamma}"'
   mathml:
   - "&#x3b3;"
   latex:
@@ -5349,27 +5369,27 @@
 - unicodemath:
   - ge
   - geq
-  - __{>=}
+  - '"P{>=}"'
   asciimath:
   - ">="
   - ge
-  - __{geq}
+  - '"P{geq}"'
   mathml:
   - "&#x2265;"
   latex:
   - geq
   - ge
-  - __{>=}
+  - "\\text{P[>=]}"
   omml:
   - "&#x2265;"
   html:
   - "&#x2265;"
 - unicodemath:
-  - __{gemini}
-  - __{Gemini}
+  - '"P{gemini}"'
+  - '"P{Gemini}"'
   asciimath:
-  - __{gemini}
-  - __{Gemini}
+  - '"P{gemini}"'
+  - '"P{Gemini}"'
   mathml:
   - "&#x264a;"
   latex:
@@ -5382,17 +5402,17 @@
 - unicodemath:
   - ge
   - geq
-  - __{>=}
+  - '"P{>=}"'
   asciimath:
   - ">="
   - ge
-  - __{geq}
+  - '"P{geq}"'
   mathml:
   - "&#x2265;"
   latex:
   - geq
   - ge
-  - __{>=}
+  - "\\text{P[>=]}"
   omml:
   - "&#x2265;"
   html:
@@ -5400,7 +5420,7 @@
 - unicodemath:
   - geqq
   asciimath:
-  - __{geqq}
+  - '"P{geqq}"'
   mathml:
   - "&#x2267;"
   latex:
@@ -5410,9 +5430,9 @@
   html:
   - "&#x2267;"
 - unicodemath:
-  - __{geqqslant}
+  - '"P{geqqslant}"'
   asciimath:
-  - __{geqqslant}
+  - '"P{geqqslant}"'
   mathml:
   - "&#x2afa;"
   latex:
@@ -5422,9 +5442,9 @@
   html:
   - "&#x2afa;"
 - unicodemath:
-  - __{geqslant}
+  - '"P{geqslant}"'
   asciimath:
-  - __{geqslant}
+  - '"P{geqslant}"'
   mathml:
   - "&#x2a7e;"
   latex:
@@ -5434,9 +5454,9 @@
   html:
   - "&#x2a7e;"
 - unicodemath:
-  - __{gescc}
+  - '"P{gescc}"'
   asciimath:
-  - __{gescc}
+  - '"P{gescc}"'
   mathml:
   - "&#x2aa9;"
   latex:
@@ -5446,9 +5466,9 @@
   html:
   - "&#x2aa9;"
 - unicodemath:
-  - __{gesdot}
+  - '"P{gesdot}"'
   asciimath:
-  - __{gesdot}
+  - '"P{gesdot}"'
   mathml:
   - "&#x2a80;"
   latex:
@@ -5458,9 +5478,9 @@
   html:
   - "&#x2a80;"
 - unicodemath:
-  - __{gesdoto}
+  - '"P{gesdoto}"'
   asciimath:
-  - __{gesdoto}
+  - '"P{gesdoto}"'
   mathml:
   - "&#x2a82;"
   latex:
@@ -5470,9 +5490,9 @@
   html:
   - "&#x2a82;"
 - unicodemath:
-  - __{gesdotol}
+  - '"P{gesdotol}"'
   asciimath:
-  - __{gesdotol}
+  - '"P{gesdotol}"'
   mathml:
   - "&#x2a84;"
   latex:
@@ -5482,9 +5502,9 @@
   html:
   - "&#x2a84;"
 - unicodemath:
-  - __{gesles}
+  - '"P{gesles}"'
   asciimath:
-  - __{gesles}
+  - '"P{gesles}"'
   mathml:
   - "&#x2a94;"
   latex:
@@ -5496,29 +5516,32 @@
 - unicodemath:
   - gets
   - leftarrow
-  - __{larr}
+  - '"P{larr}"'
   asciimath:
   - leftarrow
   - larr
-  - __{gets}
+  - '"P{gets}"'
   mathml:
   - "&#x2190;"
   latex:
   - leftarrow
   - gets
-  - __{larr}
+  - "\\text{P[larr]}"
   omml:
   - "&#x2190;"
   html:
   - "&#x2190;"
 - unicodemath:
   - gg
+  - '"P{mgt}"'
   asciimath:
-  - __{gg}
+  - gg
+  - mgt
   mathml:
   - "&#x226b;"
   latex:
   - gg
+  - "\\text{P[mgt]}"
   omml:
   - "&#x226b;"
   html:
@@ -5526,7 +5549,7 @@
 - unicodemath:
   - ggg
   asciimath:
-  - __{ggg}
+  - '"P{ggg}"'
   mathml:
   - "&#x22d9;"
   latex:
@@ -5536,9 +5559,9 @@
   html:
   - "&#x22d9;"
 - unicodemath:
-  - __{gggnest}
+  - '"P{gggnest}"'
   asciimath:
-  - __{gggnest}
+  - '"P{gggnest}"'
   mathml:
   - "&#x2af8;"
   latex:
@@ -5550,7 +5573,7 @@
 - unicodemath:
   - gimel
   asciimath:
-  - __{gimel}
+  - '"P{gimel}"'
   mathml:
   - "&#x2137;"
   latex:
@@ -5560,9 +5583,9 @@
   html:
   - "&#x2137;"
 - unicodemath:
-  - __{gla}
+  - '"P{gla}"'
   asciimath:
-  - __{gla}
+  - '"P{gla}"'
   mathml:
   - "&#x2aa5;"
   latex:
@@ -5572,9 +5595,9 @@
   html:
   - "&#x2aa5;"
 - unicodemath:
-  - __{glE}
+  - '"P{glE}"'
   asciimath:
-  - __{glE}
+  - '"P{glE}"'
   mathml:
   - "&#x2a92;"
   latex:
@@ -5584,9 +5607,9 @@
   html:
   - "&#x2a92;"
 - unicodemath:
-  - __{gleichstark}
+  - '"P{gleichstark}"'
   asciimath:
-  - __{gleichstark}
+  - '"P{gleichstark}"'
   mathml:
   - "&#x29e6;"
   latex:
@@ -5596,9 +5619,9 @@
   html:
   - "&#x29e6;"
 - unicodemath:
-  - __{glj}
+  - '"P{glj}"'
   asciimath:
-  - __{glj}
+  - '"P{glj}"'
   mathml:
   - "&#x2aa4;"
   latex:
@@ -5608,9 +5631,9 @@
   html:
   - "&#x2aa4;"
 - unicodemath:
-  - __{gnapprox}
+  - '"P{gnapprox}"'
   asciimath:
-  - __{gnapprox}
+  - '"P{gnapprox}"'
   mathml:
   - "&#x2a8a;"
   latex:
@@ -5620,9 +5643,9 @@
   html:
   - "&#x2a8a;"
 - unicodemath:
-  - __{gneq}
+  - '"P{gneq}"'
   asciimath:
-  - __{gneq}
+  - '"P{gneq}"'
   mathml:
   - "&#x2a88;"
   latex:
@@ -5634,7 +5657,7 @@
 - unicodemath:
   - gneqq
   asciimath:
-  - __{gneqq}
+  - '"P{gneqq}"'
   mathml:
   - "&#x2269;"
   latex:
@@ -5644,9 +5667,9 @@
   html:
   - "&#x2269;"
 - unicodemath:
-  - __{gnsim}
+  - '"P{gnsim}"'
   asciimath:
-  - __{gnsim}
+  - '"P{gnsim}"'
   mathml:
   - "&#x22e7;"
   latex:
@@ -5657,7 +5680,7 @@
   - "&#x22e7;"
 - unicodemath:
   - nabla
-  - __{grad}
+  - '"P{grad}"'
   asciimath:
   - nabla
   - grad
@@ -5665,15 +5688,15 @@
   - "&#x2207;"
   latex:
   - nabla
-  - __{grad}
+  - "\\text{P[grad]}"
   omml:
   - "&#x2207;"
   html:
   - "&#x2207;"
 - unicodemath:
-  - __{grave}
+  - '"P{grave}"'
   asciimath:
-  - __{grave}
+  - '"P{grave}"'
   mathml:
   - "&#x300;"
   latex:
@@ -5684,29 +5707,29 @@
   - "&#x300;"
 - unicodemath:
   - "&gt;"
-  - __{>}
-  - __{gt}
-  - __{greater}
+  - '"P{>}"'
+  - '"P{gt}"'
+  - '"P{greater}"'
   asciimath:
   - ">"
   - gt
   - "&gt;"
-  - __{greater}
+  - '"P{greater}"'
   mathml:
   - "&gt;"
   latex:
   - greater
   - ">"
   - "&gt;"
-  - __{gt}
+  - "\\text{P[gt]}"
   omml:
   - "&gt;"
   html:
   - "&#x3e;"
 - unicodemath:
-  - __{gsime}
+  - '"P{gsime}"'
   asciimath:
-  - __{gsime}
+  - '"P{gsime}"'
   mathml:
   - "&#x2a8e;"
   latex:
@@ -5716,9 +5739,9 @@
   html:
   - "&#x2a8e;"
 - unicodemath:
-  - __{gsiml}
+  - '"P{gsiml}"'
   asciimath:
-  - __{gsiml}
+  - '"P{gsiml}"'
   mathml:
   - "&#x2a90;"
   latex:
@@ -5729,31 +5752,31 @@
   - "&#x2a90;"
 - unicodemath:
   - "&gt;"
-  - __{>}
-  - __{gt}
-  - __{greater}
+  - '"P{>}"'
+  - '"P{gt}"'
+  - '"P{greater}"'
   asciimath:
   - ">"
   - gt
   - "&gt;"
-  - __{greater}
+  - '"P{greater}"'
   mathml:
   - "&gt;"
   latex:
   - greater
   - ">"
   - "&gt;"
-  - __{gt}
+  - "\\text{P[gt]}"
   omml:
   - "&gt;"
   html:
   - "&#x3e;"
 - unicodemath:
-  - __{rightslice}
-  - __{gtcc}
+  - '"P{rightslice}"'
+  - '"P{gtcc}"'
   asciimath:
-  - __{rightslice}
-  - __{gtcc}
+  - '"P{rightslice}"'
+  - '"P{gtcc}"'
   mathml:
   - "&#x2aa7;"
   latex:
@@ -5764,9 +5787,9 @@
   html:
   - "&#x2aa7;"
 - unicodemath:
-  - __{gtcir}
+  - '"P{gtcir}"'
   asciimath:
-  - __{gtcir}
+  - '"P{gtcir}"'
   mathml:
   - "&#x2a7a;"
   latex:
@@ -5776,9 +5799,9 @@
   html:
   - "&#x2a7a;"
 - unicodemath:
-  - __{gtlpar}
+  - '"P{gtlpar}"'
   asciimath:
-  - __{gtlpar}
+  - '"P{gtlpar}"'
   mathml:
   - "&#x29a0;"
   latex:
@@ -5788,9 +5811,9 @@
   html:
   - "&#x29a0;"
 - unicodemath:
-  - __{gtquest}
+  - '"P{gtquest}"'
   asciimath:
-  - __{gtquest}
+  - '"P{gtquest}"'
   mathml:
   - "&#x2a7c;"
   latex:
@@ -5800,9 +5823,9 @@
   html:
   - "&#x2a7c;"
 - unicodemath:
-  - __{gtrapprox}
+  - '"P{gtrapprox}"'
   asciimath:
-  - __{gtrapprox}
+  - '"P{gtrapprox}"'
   mathml:
   - "&#x2a86;"
   latex:
@@ -5812,9 +5835,9 @@
   html:
   - "&#x2a86;"
 - unicodemath:
-  - __{gtrarr}
+  - '"P{gtrarr}"'
   asciimath:
-  - __{gtrarr}
+  - '"P{gtrarr}"'
   mathml:
   - "&#x2978;"
   latex:
@@ -5826,7 +5849,7 @@
 - unicodemath:
   - gtrdot
   asciimath:
-  - __{gtrdot}
+  - '"P{gtrdot}"'
   mathml:
   - "&#x22d7;"
   latex:
@@ -5838,7 +5861,7 @@
 - unicodemath:
   - gtreqless
   asciimath:
-  - __{gtreqless}
+  - '"P{gtreqless}"'
   mathml:
   - "&#x22db;"
   latex:
@@ -5848,9 +5871,9 @@
   html:
   - "&#x22db;"
 - unicodemath:
-  - __{gtreqqless}
+  - '"P{gtreqqless}"'
   asciimath:
-  - __{gtreqqless}
+  - '"P{gtreqqless}"'
   mathml:
   - "&#x2a8c;"
   latex:
@@ -5861,10 +5884,10 @@
   - "&#x2a8c;"
 - unicodemath:
   - gtrless
-  - __{GreaterLess}
+  - '"P{GreaterLess}"'
   asciimath:
-  - __{gtrless}
-  - __{GreaterLess}
+  - '"P{gtrless}"'
+  - '"P{GreaterLess}"'
   mathml:
   - "&#x2277;"
   latex:
@@ -5876,9 +5899,9 @@
   - "&#x2277;"
 - unicodemath:
   - Leftrightarrow
-  - __{<=>}
-  - __{hArr}
-  - __{iff}
+  - '"P{<=>}"'
+  - '"P{hArr}"'
+  - '"P{iff}"'
   asciimath:
   - Leftrightarrow
   - "<=>"
@@ -5888,19 +5911,19 @@
   - "&#x21d4;"
   latex:
   - Leftrightarrow
-  - __{<=>}
-  - __{hArr}
-  - __{iff}
+  - "\\text{P[<=>]}"
+  - "\\text{P[hArr]}"
+  - "\\text{P[iff]}"
   omml:
   - "&#x21d4;"
   html:
   - "&#x21d4;"
 - unicodemath:
-  - __{equalparallel}
-  - __{hash}
+  - '"P{equalparallel}"'
+  - '"P{hash}"'
   asciimath:
-  - __{equalparallel}
-  - __{hash}
+  - '"P{equalparallel}"'
+  - '"P{hash}"'
   mathml:
   - "&#x22d5;"
   latex:
@@ -5923,9 +5946,9 @@
   html:
   - "^"
 - unicodemath:
-  - __{hatapprox}
+  - '"P{hatapprox}"'
   asciimath:
-  - __{hatapprox}
+  - '"P{hatapprox}"'
   mathml:
   - "&#x2a6f;"
   latex:
@@ -5936,38 +5959,38 @@
   - "&#x2a6f;"
 - unicodemath:
   - hbar
-  - __{hslash}
+  - '"P{hslash}"'
   asciimath:
-  - __{hbar}
-  - __{hslash}
+  - '"P{hbar}"'
+  - '"P{hslash}"'
   mathml:
   - "&#x210f;"
   latex:
   - hslash
-  - __{hbar}
+  - "\\text{P[hbar]}"
   omml:
   - "&#x210f;"
   html:
   - "&#x210f;"
 - unicodemath:
   - hearsuit
-  - __{heartsuit}
+  - '"P{heartsuit}"'
   asciimath:
-  - __{hearsuit}
-  - __{heartsuit}
+  - '"P{hearsuit}"'
+  - '"P{heartsuit}"'
   mathml:
   - "&#x2661;"
   latex:
   - heartsuit
-  - __{hearsuit}
+  - "\\text{P[hearsuit]}"
   omml:
   - "&#x2661;"
   html:
   - "&#x2661;"
 - unicodemath:
-  - __{Hermaphrodite}
+  - '"P{Hermaphrodite}"'
   asciimath:
-  - __{Hermaphrodite}
+  - '"P{Hermaphrodite}"'
   mathml:
   - "&#x26a5;"
   latex:
@@ -5977,9 +6000,9 @@
   html:
   - "&#x26a5;"
 - unicodemath:
-  - __{hermitmatrix}
+  - '"P{hermitmatrix}"'
   asciimath:
-  - __{hermitmatrix}
+  - '"P{hermitmatrix}"'
   mathml:
   - "&#x22b9;"
   latex:
@@ -5989,9 +6012,9 @@
   html:
   - "&#x22b9;"
 - unicodemath:
-  - __{hexagon}
+  - '"P{hexagon}"'
   asciimath:
-  - __{hexagon}
+  - '"P{hexagon}"'
   mathml:
   - "&#x2394;"
   latex:
@@ -6001,9 +6024,9 @@
   html:
   - "&#x2394;"
 - unicodemath:
-  - __{hexagonblack}
+  - '"P{hexagonblack}"'
   asciimath:
-  - __{hexagonblack}
+  - '"P{hexagonblack}"'
   mathml:
   - "&#x2b23;"
   latex:
@@ -6013,13 +6036,13 @@
   html:
   - "&#x2b23;"
 - unicodemath:
-  - __{zhide}
-  - __{xbsol}
-  - __{hide}
+  - '"P{zhide}"'
+  - '"P{xbsol}"'
+  - '"P{hide}"'
   asciimath:
-  - __{zhide}
-  - __{xbsol}
-  - __{hide}
+  - '"P{zhide}"'
+  - '"P{xbsol}"'
+  - '"P{hide}"'
   mathml:
   - "&#x29f9;"
   latex:
@@ -6031,9 +6054,9 @@
   html:
   - "&#x29f9;"
 - unicodemath:
-  - __{hknearrow}
+  - '"P{hknearrow}"'
   asciimath:
-  - __{hknearrow}
+  - '"P{hknearrow}"'
   mathml:
   - "&#x2924;"
   latex:
@@ -6043,9 +6066,9 @@
   html:
   - "&#x2924;"
 - unicodemath:
-  - __{hknwarrow}
+  - '"P{hknwarrow}"'
   asciimath:
-  - __{hknwarrow}
+  - '"P{hknwarrow}"'
   mathml:
   - "&#x2923;"
   latex:
@@ -6055,9 +6078,9 @@
   html:
   - "&#x2923;"
 - unicodemath:
-  - __{hksearow}
+  - '"P{hksearow}"'
   asciimath:
-  - __{hksearow}
+  - '"P{hksearow}"'
   mathml:
   - "&#x2925;"
   latex:
@@ -6067,9 +6090,9 @@
   html:
   - "&#x2925;"
 - unicodemath:
-  - __{hkswarow}
+  - '"P{hkswarow}"'
   asciimath:
-  - __{hkswarow}
+  - '"P{hkswarow}"'
   mathml:
   - "&#x2926;"
   latex:
@@ -6079,11 +6102,11 @@
   html:
   - "&#x2926;"
 - unicodemath:
-  - __{harrowextender}
-  - __{hline}
+  - '"P{harrowextender}"'
+  - '"P{hline}"'
   asciimath:
-  - __{harrowextender}
-  - __{hline}
+  - '"P{harrowextender}"'
+  - '"P{hline}"'
   mathml:
   - "&#x23af;"
   latex:
@@ -6096,7 +6119,7 @@
 - unicodemath:
   - hookleftarrow
   asciimath:
-  - __{hookleftarrow}
+  - '"P{hookleftarrow}"'
   mathml:
   - "&#x21a9;"
   latex:
@@ -6108,7 +6131,7 @@
 - unicodemath:
   - hookrightarrow
   asciimath:
-  - __{hookrightarrow}
+  - '"P{hookrightarrow}"'
   mathml:
   - "&#x21aa;"
   latex:
@@ -6118,9 +6141,9 @@
   html:
   - "&#x21aa;"
 - unicodemath:
-  - __{horizbar}
+  - '"P{horizbar}"'
   asciimath:
-  - __{horizbar}
+  - '"P{horizbar}"'
   mathml:
   - "&#x2015;"
   latex:
@@ -6130,9 +6153,9 @@
   html:
   - "&#x2015;"
 - unicodemath:
-  - __{hourglass}
+  - '"P{hourglass}"'
   asciimath:
-  - __{hourglass}
+  - '"P{hourglass}"'
   mathml:
   - "&#x29d6;"
   latex:
@@ -6142,9 +6165,9 @@
   html:
   - "&#x29d6;"
 - unicodemath:
-  - __{house}
+  - '"P{house}"'
   asciimath:
-  - __{house}
+  - '"P{house}"'
   mathml:
   - "&#x2302;"
   latex:
@@ -6154,9 +6177,9 @@
   html:
   - "&#x2302;"
 - unicodemath:
-  - __{hrectangle}
+  - '"P{hrectangle}"'
   asciimath:
-  - __{hrectangle}
+  - '"P{hrectangle}"'
   mathml:
   - "&#x25ad;"
   latex:
@@ -6166,9 +6189,9 @@
   html:
   - "&#x25ad;"
 - unicodemath:
-  - __{hrectangleblack}
+  - '"P{hrectangleblack}"'
   asciimath:
-  - __{hrectangleblack}
+  - '"P{hrectangleblack}"'
   mathml:
   - "&#x25ac;"
   latex:
@@ -6178,9 +6201,9 @@
   html:
   - "&#x25ac;"
 - unicodemath:
-  - __{hyphenbullet}
+  - '"P{hyphenbullet}"'
   asciimath:
-  - __{hyphenbullet}
+  - '"P{hyphenbullet}"'
   mathml:
   - "&#x2043;"
   latex:
@@ -6190,9 +6213,9 @@
   html:
   - "&#x2043;"
 - unicodemath:
-  - __{hzigzag}
+  - '"P{hzigzag}"'
   asciimath:
-  - __{hzigzag}
+  - '"P{hzigzag}"'
   mathml:
   - "&#x3030;"
   latex:
@@ -6215,25 +6238,25 @@
   - if
 - unicodemath:
   - iff
-  - __{longrightsquigarrow}
+  - '"P{longrightsquigarrow}"'
   asciimath:
-  - __{iff}
-  - __{longrightsquigarrow}
+  - '"P{iff}"'
+  - '"P{longrightsquigarrow}"'
   mathml:
   - "&#x27ff;"
   latex:
   - longrightsquigarrow
-  - __{iff}
+  - "\\text{P[iff]}"
   omml:
   - "&#x27ff;"
   html:
   - "&#x27ff;"
 - unicodemath:
   - ii
-  - __{ComplexI}
+  - '"P{ComplexI}"'
   asciimath:
-  - __{ii}
-  - __{ComplexI}
+  - '"P{ii}"'
+  - '"P{ComplexI}"'
   mathml:
   - "&#x2148;"
   latex:
@@ -6244,9 +6267,9 @@
   html:
   - "&#x2148;"
 - unicodemath:
-  - __{iiiint}
+  - '"P{iiiint}"'
   asciimath:
-  - __{iiiint}
+  - '"P{iiiint}"'
   mathml:
   - "&#x2a0c;"
   latex:
@@ -6256,9 +6279,9 @@
   html:
   - "&#x2a0c;"
 - unicodemath:
-  - __{iiint}
+  - '"P{iiint}"'
   asciimath:
-  - __{iiint}
+  - '"P{iiint}"'
   mathml:
   - "&#x222d;"
   latex:
@@ -6268,9 +6291,9 @@
   html:
   - "&#x222d;"
 - unicodemath:
-  - __{iinfin}
+  - '"P{iinfin}"'
   asciimath:
-  - __{iinfin}
+  - '"P{iinfin}"'
   mathml:
   - "&#x29dc;"
   latex:
@@ -6280,9 +6303,9 @@
   html:
   - "&#x29dc;"
 - unicodemath:
-  - __{iint}
+  - '"P{iint}"'
   asciimath:
-  - __{iint}
+  - '"P{iint}"'
   mathml:
   - "&#x222c;"
   latex:
@@ -6294,7 +6317,7 @@
 - unicodemath:
   - Im
   asciimath:
-  - __{Im}
+  - '"P{Im}"'
   mathml:
   - "&#x2111;"
   latex:
@@ -6304,11 +6327,11 @@
   html:
   - "&#x2111;"
 - unicodemath:
-  - __{multimapdotbothB}
-  - __{imageof}
+  - '"P{multimapdotbothB}"'
+  - '"P{imageof}"'
   asciimath:
-  - __{multimapdotbothB}
-  - __{imageof}
+  - '"P{multimapdotbothB}"'
+  - '"P{imageof}"'
   mathml:
   - "&#x22b7;"
   latex:
@@ -6321,7 +6344,7 @@
 - unicodemath:
   - imath
   asciimath:
-  - __{imath}
+  - '"P{imath}"'
   mathml:
   - "&#x131;"
   latex:
@@ -6332,10 +6355,10 @@
   - "&#x131;"
 - unicodemath:
   - Longleftarrow
-  - __{impliedby}
+  - '"P{impliedby}"'
   asciimath:
-  - __{Longleftarrow}
-  - __{impliedby}
+  - '"P{Longleftarrow}"'
+  - '"P{impliedby}"'
   mathml:
   - "&#x27f8;"
   latex:
@@ -6359,15 +6382,15 @@
   - "&#x2208;"
 - unicodemath:
   - inc
-  - __{increment}
+  - '"P{increment}"'
   asciimath:
-  - __{inc}
-  - __{increment}
+  - '"P{inc}"'
+  - '"P{increment}"'
   mathml:
   - "&#x2206;"
   latex:
   - increment
-  - __{inc}
+  - "\\text{P[inc]}"
   omml:
   - "&#x2206;"
   html:
@@ -6385,9 +6408,9 @@
   html:
   - "&#x222b;"
 - unicodemath:
-  - __{intBar}
+  - '"P{intBar}"'
   asciimath:
-  - __{intBar}
+  - '"P{intBar}"'
   mathml:
   - "&#x2a0e;"
   latex:
@@ -6397,9 +6420,9 @@
   html:
   - "&#x2a0e;"
 - unicodemath:
-  - __{intbottom}
+  - '"P{intbottom}"'
   asciimath:
-  - __{intbottom}
+  - '"P{intbottom}"'
   mathml:
   - "&#x2321;"
   latex:
@@ -6409,9 +6432,9 @@
   html:
   - "&#x2321;"
 - unicodemath:
-  - __{intcap}
+  - '"P{intcap}"'
   asciimath:
-  - __{intcap}
+  - '"P{intcap}"'
   mathml:
   - "&#x2a19;"
   latex:
@@ -6421,9 +6444,9 @@
   html:
   - "&#x2a19;"
 - unicodemath:
-  - __{intclockwise}
+  - '"P{intclockwise}"'
   asciimath:
-  - __{intclockwise}
+  - '"P{intclockwise}"'
   mathml:
   - "&#x2231;"
   latex:
@@ -6433,9 +6456,9 @@
   html:
   - "&#x2231;"
 - unicodemath:
-  - __{intcup}
+  - '"P{intcup}"'
   asciimath:
-  - __{intcup}
+  - '"P{intcup}"'
   mathml:
   - "&#x2a1a;"
   latex:
@@ -6447,7 +6470,7 @@
 - unicodemath:
   - intercal
   asciimath:
-  - __{intercal}
+  - '"P{intercal}"'
   mathml:
   - "&#x22ba;"
   latex:
@@ -6457,9 +6480,9 @@
   html:
   - "&#x22ba;"
 - unicodemath:
-  - __{interleave}
+  - '"P{interleave}"'
   asciimath:
-  - __{interleave}
+  - '"P{interleave}"'
   mathml:
   - "&#x2af4;"
   latex:
@@ -6469,9 +6492,9 @@
   html:
   - "&#x2af4;"
 - unicodemath:
-  - __{intextender}
+  - '"P{intextender}"'
   asciimath:
-  - __{intextender}
+  - '"P{intextender}"'
   mathml:
   - "&#x23ae;"
   latex:
@@ -6481,9 +6504,9 @@
   html:
   - "&#x23ae;"
 - unicodemath:
-  - __{intlarhk}
+  - '"P{intlarhk}"'
   asciimath:
-  - __{intlarhk}
+  - '"P{intlarhk}"'
   mathml:
   - "&#x2a17;"
   latex:
@@ -6493,9 +6516,9 @@
   html:
   - "&#x2a17;"
 - unicodemath:
-  - __{intprod}
+  - '"P{intprod}"'
   asciimath:
-  - __{intprod}
+  - '"P{intprod}"'
   mathml:
   - "&#x2a3c;"
   latex:
@@ -6505,9 +6528,9 @@
   html:
   - "&#x2a3c;"
 - unicodemath:
-  - __{intprodr}
+  - '"P{intprodr}"'
   asciimath:
-  - __{intprodr}
+  - '"P{intprodr}"'
   mathml:
   - "&#x2a3d;"
   latex:
@@ -6517,9 +6540,9 @@
   html:
   - "&#x2a3d;"
 - unicodemath:
-  - __{inttop}
+  - '"P{inttop}"'
   asciimath:
-  - __{inttop}
+  - '"P{inttop}"'
   mathml:
   - "&#x2320;"
   latex:
@@ -6529,9 +6552,9 @@
   html:
   - "&#x2320;"
 - unicodemath:
-  - __{intx}
+  - '"P{intx}"'
   asciimath:
-  - __{intx}
+  - '"P{intx}"'
   mathml:
   - "&#x2a18;"
   latex:
@@ -6541,9 +6564,9 @@
   html:
   - "&#x2a18;"
 - unicodemath:
-  - __{invdiameter}
+  - '"P{invdiameter}"'
   asciimath:
-  - __{invdiameter}
+  - '"P{invdiameter}"'
   mathml:
   - "&#x2349;"
   latex:
@@ -6553,9 +6576,9 @@
   html:
   - "&#x2349;"
 - unicodemath:
-  - __{inversebullet}
+  - '"P{inversebullet}"'
   asciimath:
-  - __{inversebullet}
+  - '"P{inversebullet}"'
   mathml:
   - "&#x25d8;"
   latex:
@@ -6565,9 +6588,9 @@
   html:
   - "&#x25d8;"
 - unicodemath:
-  - __{inversewhitecircle}
+  - '"P{inversewhitecircle}"'
   asciimath:
-  - __{inversewhitecircle}
+  - '"P{inversewhitecircle}"'
   mathml:
   - "&#x25d9;"
   latex:
@@ -6577,9 +6600,9 @@
   html:
   - "&#x25d9;"
 - unicodemath:
-  - __{invlazys}
+  - '"P{invlazys}"'
   asciimath:
-  - __{invlazys}
+  - '"P{invlazys}"'
   mathml:
   - "&#x223e;"
   latex:
@@ -6589,11 +6612,11 @@
   html:
   - "&#x223e;"
 - unicodemath:
-  - __{invneg}
-  - __{invnot}
+  - '"P{invneg}"'
+  - '"P{invnot}"'
   asciimath:
-  - __{invneg}
-  - __{invnot}
+  - '"P{invneg}"'
+  - '"P{invnot}"'
   mathml:
   - "&#x2310;"
   latex:
@@ -6604,9 +6627,9 @@
   html:
   - "&#x2310;"
 - unicodemath:
-  - __{invwhitelowerhalfcircle}
+  - '"P{invwhitelowerhalfcircle}"'
   asciimath:
-  - __{invwhitelowerhalfcircle}
+  - '"P{invwhitelowerhalfcircle}"'
   mathml:
   - "&#x25db;"
   latex:
@@ -6616,9 +6639,9 @@
   html:
   - "&#x25db;"
 - unicodemath:
-  - __{invwhiteupperhalfcircle}
+  - '"P{invwhiteupperhalfcircle}"'
   asciimath:
-  - __{invwhiteupperhalfcircle}
+  - '"P{invwhiteupperhalfcircle}"'
   mathml:
   - "&#x25da;"
   latex:
@@ -6629,10 +6652,10 @@
   - "&#x25da;"
 - unicodemath:
   - iota
-  - __{upiota}
+  - '"P{upiota}"'
   asciimath:
   - iota
-  - __{upiota}
+  - '"P{upiota}"'
   mathml:
   - "&#x3b9;"
   latex:
@@ -6643,9 +6666,9 @@
   html:
   - "&#x3b9;"
 - unicodemath:
-  - __{isindot}
+  - '"P{isindot}"'
   asciimath:
-  - __{isindot}
+  - '"P{isindot}"'
   mathml:
   - "&#x22f5;"
   latex:
@@ -6655,9 +6678,9 @@
   html:
   - "&#x22f5;"
 - unicodemath:
-  - __{isinE}
+  - '"P{isinE}"'
   asciimath:
-  - __{isinE}
+  - '"P{isinE}"'
   mathml:
   - "&#x22f9;"
   latex:
@@ -6667,9 +6690,9 @@
   html:
   - "&#x22f9;"
 - unicodemath:
-  - __{isinobar}
+  - '"P{isinobar}"'
   asciimath:
-  - __{isinobar}
+  - '"P{isinobar}"'
   mathml:
   - "&#x22f7;"
   latex:
@@ -6679,9 +6702,9 @@
   html:
   - "&#x22f7;"
 - unicodemath:
-  - __{isins}
+  - '"P{isins}"'
   asciimath:
-  - __{isins}
+  - '"P{isins}"'
   mathml:
   - "&#x22f4;"
   latex:
@@ -6691,9 +6714,9 @@
   html:
   - "&#x22f4;"
 - unicodemath:
-  - __{isinvb}
+  - '"P{isinvb}"'
   asciimath:
-  - __{isinvb}
+  - '"P{isinvb}"'
   mathml:
   - "&#x22f8;"
   latex:
@@ -6704,10 +6727,10 @@
   - "&#x22f8;"
 - unicodemath:
   - jj
-  - __{ComplexJ}
+  - '"P{ComplexJ}"'
   asciimath:
-  - __{jj}
-  - __{ComplexJ}
+  - '"P{jj}"'
+  - '"P{ComplexJ}"'
   mathml:
   - "&#x2149;"
   latex:
@@ -6720,7 +6743,7 @@
 - unicodemath:
   - jmath
   asciimath:
-  - __{jmath}
+  - '"P{jmath}"'
   mathml:
   - "&#x237;"
   latex:
@@ -6730,9 +6753,9 @@
   html:
   - "&#x237;"
 - unicodemath:
-  - __{Join}
+  - '"P{Join}"'
   asciimath:
-  - __{Join}
+  - '"P{Join}"'
   mathml:
   - "&#x2a1d;"
   latex:
@@ -6742,11 +6765,11 @@
   html:
   - "&#x2a1d;"
 - unicodemath:
-  - __{jupiter}
-  - __{Jupiter}
+  - '"P{jupiter}"'
+  - '"P{Jupiter}"'
   asciimath:
-  - __{jupiter}
-  - __{Jupiter}
+  - '"P{jupiter}"'
+  - '"P{Jupiter}"'
   mathml:
   - "&#x2643;"
   latex:
@@ -6758,10 +6781,10 @@
   - "&#x2643;"
 - unicodemath:
   - kappa
-  - __{upkappa}
+  - '"P{upkappa}"'
   asciimath:
   - kappa
-  - __{upkappa}
+  - '"P{upkappa}"'
   mathml:
   - "&#x3ba;"
   latex:
@@ -6772,9 +6795,9 @@
   html:
   - "&#x3ba;"
 - unicodemath:
-  - __{kernelcontraction}
+  - '"P{kernelcontraction}"'
   asciimath:
-  - __{kernelcontraction}
+  - '"P{kernelcontraction}"'
   mathml:
   - "&#x223b;"
   latex:
@@ -6784,13 +6807,13 @@
   html:
   - "&#x223b;"
 - unicodemath:
-  - __{upoldkoppa}
-  - __{qoppa}
-  - __{koppa}
+  - '"P{upoldkoppa}"'
+  - '"P{qoppa}"'
+  - '"P{koppa}"'
   asciimath:
-  - __{upoldkoppa}
-  - __{qoppa}
-  - __{koppa}
+  - '"P{upoldkoppa}"'
+  - '"P{qoppa}"'
+  - '"P{koppa}"'
   mathml:
   - "&#x3d9;"
   latex:
@@ -6803,10 +6826,10 @@
   - "&#x3d9;"
 - unicodemath:
   - lambda
-  - __{uplambda}
+  - '"P{uplambda}"'
   asciimath:
   - lambda
-  - __{uplambda}
+  - '"P{uplambda}"'
   mathml:
   - "&#x3bb;"
   latex:
@@ -6818,28 +6841,28 @@
   - "&#x3bb;"
 - unicodemath:
   - wedge
-  - __{^^}
-  - __{land}
+  - '"P{^^}"'
+  - '"P{land}"'
   asciimath:
   - wedge
   - "^^"
-  - __{land}
+  - '"P{land}"'
   mathml:
   - "&#x2227;"
   latex:
   - wedge
   - land
-  - __{^^}
+  - "\\text{P[^^]}"
   omml:
   - "&#x2227;"
   html:
   - "&#x2227;"
 - unicodemath:
-  - __{lAngle}
-  - __{lang}
+  - '"P{lAngle}"'
+  - '"P{lang}"'
   asciimath:
-  - __{lAngle}
-  - __{lang}
+  - '"P{lAngle}"'
+  - '"P{lang}"'
   mathml:
   - "&#x27ea;"
   latex:
@@ -6850,9 +6873,9 @@
   html:
   - "&#x27ea;"
 - unicodemath:
-  - __{langledot}
+  - '"P{langledot}"'
   asciimath:
-  - __{langledot}
+  - '"P{langledot}"'
   mathml:
   - "&#x2991;"
   latex:
@@ -6862,9 +6885,9 @@
   html:
   - "&#x2991;"
 - unicodemath:
-  - __{laplac}
+  - '"P{laplac}"'
   asciimath:
-  - __{laplac}
+  - '"P{laplac}"'
   mathml:
   - "&#x29e0;"
   latex:
@@ -6875,7 +6898,7 @@
   - "&#x29e0;"
 - unicodemath:
   - Leftarrow
-  - __{lArr}
+  - '"P{lArr}"'
   asciimath:
   - Leftarrow
   - lArr
@@ -6883,15 +6906,15 @@
   - "&#x21d0;"
   latex:
   - Leftarrow
-  - __{lArr}
+  - "\\text{P[lArr]}"
   omml:
   - "&#x21d0;"
   html:
   - "&#x21d0;"
 - unicodemath:
-  - __{lat}
+  - '"P{lat}"'
   asciimath:
-  - __{lat}
+  - '"P{lat}"'
   mathml:
   - "&#x2aab;"
   latex:
@@ -6901,9 +6924,9 @@
   html:
   - "&#x2aab;"
 - unicodemath:
-  - __{late}
+  - '"P{late}"'
   asciimath:
-  - __{late}
+  - '"P{late}"'
   mathml:
   - "&#x2aad;"
   latex:
@@ -6913,11 +6936,11 @@
   html:
   - "&#x2aad;"
 - unicodemath:
-  - __{Lbag}
-  - __{lbag}
+  - '"P{Lbag}"'
+  - '"P{lbag}"'
   asciimath:
-  - __{Lbag}
-  - __{lbag}
+  - '"P{Lbag}"'
+  - '"P{lbag}"'
   mathml:
   - "&#x27c5;"
   latex:
@@ -6928,9 +6951,9 @@
   html:
   - "&#x27c5;"
 - unicodemath:
-  - __{lblkbrbrak}
+  - '"P{lblkbrbrak}"'
   asciimath:
-  - __{lblkbrbrak}
+  - '"P{lblkbrbrak}"'
   mathml:
   - "&#x2997;"
   latex:
@@ -6940,11 +6963,11 @@
   html:
   - "&#x2997;"
 - unicodemath:
-  - __{llangle}
-  - __{lblot}
+  - '"P{llangle}"'
+  - '"P{lblot}"'
   asciimath:
-  - __{llangle}
-  - __{lblot}
+  - '"P{llangle}"'
+  - '"P{lblot}"'
   mathml:
   - "&#x2989;"
   latex:
@@ -6955,9 +6978,9 @@
   html:
   - "&#x2989;"
 - unicodemath:
-  - __{lbracelend}
+  - '"P{lbracelend}"'
   asciimath:
-  - __{lbracelend}
+  - '"P{lbracelend}"'
   mathml:
   - "&#x23a9;"
   latex:
@@ -6967,9 +6990,9 @@
   html:
   - "&#x23a9;"
 - unicodemath:
-  - __{lbracemid}
+  - '"P{lbracemid}"'
   asciimath:
-  - __{lbracemid}
+  - '"P{lbracemid}"'
   mathml:
   - "&#x23a8;"
   latex:
@@ -6979,9 +7002,9 @@
   html:
   - "&#x23a8;"
 - unicodemath:
-  - __{lbraceuend}
+  - '"P{lbraceuend}"'
   asciimath:
-  - __{lbraceuend}
+  - '"P{lbraceuend}"'
   mathml:
   - "&#x23a7;"
   latex:
@@ -6991,9 +7014,9 @@
   html:
   - "&#x23a7;"
 - unicodemath:
-  - __{lbrackextender}
+  - '"P{lbrackextender}"'
   asciimath:
-  - __{lbrackextender}
+  - '"P{lbrackextender}"'
   mathml:
   - "&#x23a2;"
   latex:
@@ -7003,9 +7026,9 @@
   html:
   - "&#x23a2;"
 - unicodemath:
-  - __{lbracklend}
+  - '"P{lbracklend}"'
   asciimath:
-  - __{lbracklend}
+  - '"P{lbracklend}"'
   mathml:
   - "&#x23a3;"
   latex:
@@ -7015,9 +7038,9 @@
   html:
   - "&#x23a3;"
 - unicodemath:
-  - __{lbracklltick}
+  - '"P{lbracklltick}"'
   asciimath:
-  - __{lbracklltick}
+  - '"P{lbracklltick}"'
   mathml:
   - "&#x298f;"
   latex:
@@ -7027,9 +7050,9 @@
   html:
   - "&#x298f;"
 - unicodemath:
-  - __{lbrackubar}
+  - '"P{lbrackubar}"'
   asciimath:
-  - __{lbrackubar}
+  - '"P{lbrackubar}"'
   mathml:
   - "&#x298b;"
   latex:
@@ -7039,9 +7062,9 @@
   html:
   - "&#x298b;"
 - unicodemath:
-  - __{lbrackuend}
+  - '"P{lbrackuend}"'
   asciimath:
-  - __{lbrackuend}
+  - '"P{lbrackuend}"'
   mathml:
   - "&#x23a1;"
   latex:
@@ -7051,9 +7074,9 @@
   html:
   - "&#x23a1;"
 - unicodemath:
-  - __{lbrackultick}
+  - '"P{lbrackultick}"'
   asciimath:
-  - __{lbrackultick}
+  - '"P{lbrackultick}"'
   mathml:
   - "&#x298d;"
   latex:
@@ -7063,9 +7086,9 @@
   html:
   - "&#x298d;"
 - unicodemath:
-  - __{Lbrbrak}
+  - '"P{Lbrbrak}"'
   asciimath:
-  - __{Lbrbrak}
+  - '"P{Lbrbrak}"'
   mathml:
   - "&#x27ec;"
   latex:
@@ -7075,9 +7098,9 @@
   html:
   - "&#x27ec;"
 - unicodemath:
-  - __{lcurvyangle}
+  - '"P{lcurvyangle}"'
   asciimath:
-  - __{lcurvyangle}
+  - '"P{lcurvyangle}"'
   mathml:
   - "&#x29fc;"
   latex:
@@ -7088,18 +7111,18 @@
   - "&#x29fc;"
 - unicodemath:
   - ldsh
-  - __{dlsh}
-  - __{Ldsh}
+  - '"P{dlsh}"'
+  - '"P{Ldsh}"'
   asciimath:
-  - __{ldsh}
-  - __{dlsh}
-  - __{Ldsh}
+  - '"P{ldsh}"'
+  - '"P{dlsh}"'
+  - '"P{Ldsh}"'
   mathml:
   - "&#x21b2;"
   latex:
   - dlsh
   - Ldsh
-  - __{ldsh}
+  - "\\text{P[ldsh]}"
   omml:
   - "&#x21b2;"
   html:
@@ -7107,27 +7130,27 @@
 - unicodemath:
   - le
   - leq
-  - __{<=}
+  - '"P{<=}"'
   asciimath:
   - "<="
   - le
-  - __{leq}
+  - '"P{leq}"'
   mathml:
   - "&#x2264;"
   latex:
   - leq
   - le
-  - __{<=}
+  - "\\text{P[<=]}"
   omml:
   - "&#x2264;"
   html:
   - "&#x2264;"
 - unicodemath:
-  - __{rightcurvedarrow}
-  - __{leadsto}
+  - '"P{rightcurvedarrow}"'
+  - '"P{leadsto}"'
   asciimath:
-  - __{rightcurvedarrow}
-  - __{leadsto}
+  - '"P{rightcurvedarrow}"'
+  - '"P{leadsto}"'
   mathml:
   - "&#x2933;"
   latex:
@@ -7139,7 +7162,7 @@
   - "&#x2933;"
 - unicodemath:
   - Leftarrow
-  - __{lArr}
+  - '"P{lArr}"'
   asciimath:
   - Leftarrow
   - lArr
@@ -7147,15 +7170,15 @@
   - "&#x21d0;"
   latex:
   - Leftarrow
-  - __{lArr}
+  - "\\text{P[lArr]}"
   omml:
   - "&#x21d0;"
   html:
   - "&#x21d0;"
 - unicodemath:
-  - __{leftarrowapprox}
+  - '"P{leftarrowapprox}"'
   asciimath:
-  - __{leftarrowapprox}
+  - '"P{leftarrowapprox}"'
   mathml:
   - "&#x2b4a;"
   latex:
@@ -7165,9 +7188,9 @@
   html:
   - "&#x2b4a;"
 - unicodemath:
-  - __{leftarrowbackapprox}
+  - '"P{leftarrowbackapprox}"'
   asciimath:
-  - __{leftarrowbackapprox}
+  - '"P{leftarrowbackapprox}"'
   mathml:
   - "&#x2b42;"
   latex:
@@ -7177,9 +7200,9 @@
   html:
   - "&#x2b42;"
 - unicodemath:
-  - __{leftarrowbsimilar}
+  - '"P{leftarrowbsimilar}"'
   asciimath:
-  - __{leftarrowbsimilar}
+  - '"P{leftarrowbsimilar}"'
   mathml:
   - "&#x2b4b;"
   latex:
@@ -7189,9 +7212,9 @@
   html:
   - "&#x2b4b;"
 - unicodemath:
-  - __{leftarrowless}
+  - '"P{leftarrowless}"'
   asciimath:
-  - __{leftarrowless}
+  - '"P{leftarrowless}"'
   mathml:
   - "&#x2977;"
   latex:
@@ -7201,9 +7224,9 @@
   html:
   - "&#x2977;"
 - unicodemath:
-  - __{leftarrowonoplus}
+  - '"P{leftarrowonoplus}"'
   asciimath:
-  - __{leftarrowonoplus}
+  - '"P{leftarrowonoplus}"'
   mathml:
   - "&#x2b32;"
   latex:
@@ -7213,9 +7236,9 @@
   html:
   - "&#x2b32;"
 - unicodemath:
-  - __{leftarrowplus}
+  - '"P{leftarrowplus}"'
   asciimath:
-  - __{leftarrowplus}
+  - '"P{leftarrowplus}"'
   mathml:
   - "&#x2946;"
   latex:
@@ -7225,9 +7248,9 @@
   html:
   - "&#x2946;"
 - unicodemath:
-  - __{leftarrowshortrightarrow}
+  - '"P{leftarrowshortrightarrow}"'
   asciimath:
-  - __{leftarrowshortrightarrow}
+  - '"P{leftarrowshortrightarrow}"'
   mathml:
   - "&#x2943;"
   latex:
@@ -7237,9 +7260,9 @@
   html:
   - "&#x2943;"
 - unicodemath:
-  - __{leftarrowsimilar}
+  - '"P{leftarrowsimilar}"'
   asciimath:
-  - __{leftarrowsimilar}
+  - '"P{leftarrowsimilar}"'
   mathml:
   - "&#x2973;"
   latex:
@@ -7249,9 +7272,9 @@
   html:
   - "&#x2973;"
 - unicodemath:
-  - __{leftarrowsubset}
+  - '"P{leftarrowsubset}"'
   asciimath:
-  - __{leftarrowsubset}
+  - '"P{leftarrowsubset}"'
   mathml:
   - "&#x297a;"
   latex:
@@ -7263,7 +7286,7 @@
 - unicodemath:
   - leftarrowtail
   asciimath:
-  - __{leftarrowtail}
+  - '"P{leftarrowtail}"'
   mathml:
   - "&#x21a2;"
   latex:
@@ -7273,9 +7296,9 @@
   html:
   - "&#x21a2;"
 - unicodemath:
-  - __{leftarrowtriangle}
+  - '"P{leftarrowtriangle}"'
   asciimath:
-  - __{leftarrowtriangle}
+  - '"P{leftarrowtriangle}"'
   mathml:
   - "&#x21fd;"
   latex:
@@ -7285,9 +7308,9 @@
   html:
   - "&#x21fd;"
 - unicodemath:
-  - __{leftarrowx}
+  - '"P{leftarrowx}"'
   asciimath:
-  - __{leftarrowx}
+  - '"P{leftarrowx}"'
   mathml:
   - "&#x2b3e;"
   latex:
@@ -7297,11 +7320,11 @@
   html:
   - "&#x2b3e;"
 - unicodemath:
-  - __{leftharpoonupdash}
-  - __{leftbarharpoon}
+  - '"P{leftharpoonupdash}"'
+  - '"P{leftbarharpoon}"'
   asciimath:
-  - __{leftharpoonupdash}
-  - __{leftbarharpoon}
+  - '"P{leftharpoonupdash}"'
+  - '"P{leftbarharpoon}"'
   mathml:
   - "&#x296a;"
   latex:
@@ -7312,9 +7335,9 @@
   html:
   - "&#x296a;"
 - unicodemath:
-  - __{leftbkarrow}
+  - '"P{leftbkarrow}"'
   asciimath:
-  - __{leftbkarrow}
+  - '"P{leftbkarrow}"'
   mathml:
   - "&#x290c;"
   latex:
@@ -7324,11 +7347,11 @@
   html:
   - "&#x290c;"
 - unicodemath:
-  - __{blacklefthalfcircle}
-  - __{LEFTCIRCLE}
+  - '"P{blacklefthalfcircle}"'
+  - '"P{LEFTCIRCLE}"'
   asciimath:
-  - __{blacklefthalfcircle}
-  - __{LEFTCIRCLE}
+  - '"P{blacklefthalfcircle}"'
+  - '"P{LEFTCIRCLE}"'
   mathml:
   - "&#x25d6;"
   latex:
@@ -7339,9 +7362,9 @@
   html:
   - "&#x25d6;"
 - unicodemath:
-  - __{leftcurvedarrow}
+  - '"P{leftcurvedarrow}"'
   asciimath:
-  - __{leftcurvedarrow}
+  - '"P{leftcurvedarrow}"'
   mathml:
   - "&#x2b3f;"
   latex:
@@ -7352,26 +7375,26 @@
   - "&#x2b3f;"
 - unicodemath:
   - curvearrowleft
-  - __{dashleftarrow}
-  - __{leftdasharrow}
+  - '"P{dashleftarrow}"'
+  - '"P{leftdasharrow}"'
   asciimath:
-  - __{curvearrowleft}
-  - __{dashleftarrow}
-  - __{leftdasharrow}
+  - '"P{curvearrowleft}"'
+  - '"P{dashleftarrow}"'
+  - '"P{leftdasharrow}"'
   mathml:
   - "&#x21e0;"
   latex:
   - dashleftarrow
   - leftdasharrow
-  - __{curvearrowleft}
+  - "\\text{P[curvearrowleft]}"
   omml:
   - "&#x21e0;"
   html:
   - "&#x21e0;"
 - unicodemath:
-  - __{leftdbkarrow}
+  - '"P{leftdbkarrow}"'
   asciimath:
-  - __{leftdbkarrow}
+  - '"P{leftdbkarrow}"'
   mathml:
   - "&#x290e;"
   latex:
@@ -7381,9 +7404,9 @@
   html:
   - "&#x290e;"
 - unicodemath:
-  - __{leftdbltail}
+  - '"P{leftdbltail}"'
   asciimath:
-  - __{leftdbltail}
+  - '"P{leftdbltail}"'
   mathml:
   - "&#x291b;"
   latex:
@@ -7393,9 +7416,9 @@
   html:
   - "&#x291b;"
 - unicodemath:
-  - __{leftdotarrow}
+  - '"P{leftdotarrow}"'
   asciimath:
-  - __{leftdotarrow}
+  - '"P{leftdotarrow}"'
   mathml:
   - "&#x2b38;"
   latex:
@@ -7405,9 +7428,9 @@
   html:
   - "&#x2b38;"
 - unicodemath:
-  - __{leftdowncurvedarrow}
+  - '"P{leftdowncurvedarrow}"'
   asciimath:
-  - __{leftdowncurvedarrow}
+  - '"P{leftdowncurvedarrow}"'
   mathml:
   - "&#x2936;"
   latex:
@@ -7417,11 +7440,11 @@
   html:
   - "&#x2936;"
 - unicodemath:
-  - __{bardownharpoonleft}
-  - __{LeftDownTeeVector}
+  - '"P{bardownharpoonleft}"'
+  - '"P{LeftDownTeeVector}"'
   asciimath:
-  - __{bardownharpoonleft}
-  - __{LeftDownTeeVector}
+  - '"P{bardownharpoonleft}"'
+  - '"P{LeftDownTeeVector}"'
   mathml:
   - "&#x2961;"
   latex:
@@ -7432,11 +7455,11 @@
   html:
   - "&#x2961;"
 - unicodemath:
-  - __{downharpoonleftbar}
-  - __{LeftDownVectorBar}
+  - '"P{downharpoonleftbar}"'
+  - '"P{LeftDownVectorBar}"'
   asciimath:
-  - __{downharpoonleftbar}
-  - __{LeftDownVectorBar}
+  - '"P{downharpoonleftbar}"'
+  - '"P{LeftDownVectorBar}"'
   mathml:
   - "&#x2959;"
   latex:
@@ -7449,7 +7472,7 @@
 - unicodemath:
   - leftharpoondown
   asciimath:
-  - __{leftharpoondown}
+  - '"P{leftharpoondown}"'
   mathml:
   - "&#x21bd;"
   latex:
@@ -7461,7 +7484,7 @@
 - unicodemath:
   - leftharpoonup
   asciimath:
-  - __{leftharpoonup}
+  - '"P{leftharpoonup}"'
   mathml:
   - "&#x21bc;"
   latex:
@@ -7473,7 +7496,7 @@
 - unicodemath:
   - leftleftarrows
   asciimath:
-  - __{leftleftarrows}
+  - '"P{leftleftarrows}"'
   mathml:
   - "&#x21c7;"
   latex:
@@ -7483,11 +7506,11 @@
   html:
   - "&#x21c7;"
 - unicodemath:
-  - __{leftharpoonsupdown}
-  - __{leftleftharpoons}
+  - '"P{leftharpoonsupdown}"'
+  - '"P{leftleftharpoons}"'
   asciimath:
-  - __{leftharpoonsupdown}
-  - __{leftleftharpoons}
+  - '"P{leftharpoonsupdown}"'
+  - '"P{leftleftharpoons}"'
   mathml:
   - "&#x2962;"
   latex:
@@ -7498,9 +7521,9 @@
   html:
   - "&#x2962;"
 - unicodemath:
-  - __{leftmoon}
+  - '"P{leftmoon}"'
   asciimath:
-  - __{leftmoon}
+  - '"P{leftmoon}"'
   mathml:
   - "&#x263e;"
   latex:
@@ -7510,9 +7533,9 @@
   html:
   - "&#x263e;"
 - unicodemath:
-  - __{leftouterjoin}
+  - '"P{leftouterjoin}"'
   asciimath:
-  - __{leftouterjoin}
+  - '"P{leftouterjoin}"'
   mathml:
   - "&#x27d5;"
   latex:
@@ -7523,9 +7546,9 @@
   - "&#x27d5;"
 - unicodemath:
   - Leftrightarrow
-  - __{<=>}
-  - __{hArr}
-  - __{iff}
+  - '"P{<=>}"'
+  - '"P{hArr}"'
+  - '"P{iff}"'
   asciimath:
   - Leftrightarrow
   - "<=>"
@@ -7535,17 +7558,17 @@
   - "&#x21d4;"
   latex:
   - Leftrightarrow
-  - __{<=>}
-  - __{hArr}
-  - __{iff}
+  - "\\text{P[<=>]}"
+  - "\\text{P[hArr]}"
+  - "\\text{P[iff]}"
   omml:
   - "&#x21d4;"
   html:
   - "&#x21d4;"
 - unicodemath:
-  - __{leftrightarrowcircle}
+  - '"P{leftrightarrowcircle}"'
   asciimath:
-  - __{leftrightarrowcircle}
+  - '"P{leftrightarrowcircle}"'
   mathml:
   - "&#x2948;"
   latex:
@@ -7557,7 +7580,7 @@
 - unicodemath:
   - leftrightarrows
   asciimath:
-  - __{leftrightarrows}
+  - '"P{leftrightarrows}"'
   mathml:
   - "&#x21c6;"
   latex:
@@ -7567,9 +7590,9 @@
   html:
   - "&#x21c6;"
 - unicodemath:
-  - __{leftrightarrowtriangle}
+  - '"P{leftrightarrowtriangle}"'
   asciimath:
-  - __{leftrightarrowtriangle}
+  - '"P{leftrightarrowtriangle}"'
   mathml:
   - "&#x21ff;"
   latex:
@@ -7579,11 +7602,11 @@
   html:
   - "&#x21ff;"
 - unicodemath:
-  - __{leftrightharpoonupdown}
-  - __{leftrightharpoon}
+  - '"P{leftrightharpoonupdown}"'
+  - '"P{leftrightharpoon}"'
   asciimath:
-  - __{leftrightharpoonupdown}
-  - __{leftrightharpoon}
+  - '"P{leftrightharpoonupdown}"'
+  - '"P{leftrightharpoon}"'
   mathml:
   - "&#x294a;"
   latex:
@@ -7594,11 +7617,11 @@
   html:
   - "&#x294a;"
 - unicodemath:
-  - __{leftrightharpoondowndown}
-  - __{leftrightharpoondown}
+  - '"P{leftrightharpoondowndown}"'
+  - '"P{leftrightharpoondown}"'
   asciimath:
-  - __{leftrightharpoondowndown}
-  - __{leftrightharpoondown}
+  - '"P{leftrightharpoondowndown}"'
+  - '"P{leftrightharpoondown}"'
   mathml:
   - "&#x2950;"
   latex:
@@ -7609,9 +7632,9 @@
   html:
   - "&#x2950;"
 - unicodemath:
-  - __{leftrightharpoonsdown}
+  - '"P{leftrightharpoonsdown}"'
   asciimath:
-  - __{leftrightharpoonsdown}
+  - '"P{leftrightharpoonsdown}"'
   mathml:
   - "&#x2967;"
   latex:
@@ -7621,9 +7644,9 @@
   html:
   - "&#x2967;"
 - unicodemath:
-  - __{leftrightharpoonsup}
+  - '"P{leftrightharpoonsup}"'
   asciimath:
-  - __{leftrightharpoonsup}
+  - '"P{leftrightharpoonsup}"'
   mathml:
   - "&#x2966;"
   latex:
@@ -7633,11 +7656,11 @@
   html:
   - "&#x2966;"
 - unicodemath:
-  - __{leftrightharpoonupup}
-  - __{leftrightharpoonup}
+  - '"P{leftrightharpoonupup}"'
+  - '"P{leftrightharpoonup}"'
   asciimath:
-  - __{leftrightharpoonupup}
-  - __{leftrightharpoonup}
+  - '"P{leftrightharpoonupup}"'
+  - '"P{leftrightharpoonup}"'
   mathml:
   - "&#x294e;"
   latex:
@@ -7649,15 +7672,15 @@
   - "&#x294e;"
 - unicodemath:
   - leftrightwavearrow
-  - __{leftrightsquigarrow}
+  - '"P{leftrightsquigarrow}"'
   asciimath:
-  - __{leftrightwavearrow}
-  - __{leftrightsquigarrow}
+  - '"P{leftrightwavearrow}"'
+  - '"P{leftrightsquigarrow}"'
   mathml:
   - "&#x21ad;"
   latex:
   - leftrightsquigarrow
-  - __{leftrightwavearrow}
+  - "\\text{P[leftrightwavearrow]}"
   omml:
   - "&#x21ad;"
   html:
@@ -7665,7 +7688,7 @@
 - unicodemath:
   - leftsquigarrow
   asciimath:
-  - __{leftsquigarrow}
+  - '"P{leftsquigarrow}"'
   mathml:
   - "&#x21dc;"
   latex:
@@ -7675,9 +7698,9 @@
   html:
   - "&#x21dc;"
 - unicodemath:
-  - __{lefttail}
+  - '"P{lefttail}"'
   asciimath:
-  - __{lefttail}
+  - '"P{lefttail}"'
   mathml:
   - "&#x2919;"
   latex:
@@ -7687,11 +7710,11 @@
   html:
   - "&#x2919;"
 - unicodemath:
-  - __{leftharpoonupbar}
-  - __{LeftTeeVector}
+  - '"P{leftharpoonupbar}"'
+  - '"P{LeftTeeVector}"'
   asciimath:
-  - __{leftharpoonupbar}
-  - __{LeftTeeVector}
+  - '"P{leftharpoonupbar}"'
+  - '"P{LeftTeeVector}"'
   mathml:
   - "&#x295a;"
   latex:
@@ -7702,9 +7725,9 @@
   html:
   - "&#x295a;"
 - unicodemath:
-  - __{leftthreearrows}
+  - '"P{leftthreearrows}"'
   asciimath:
-  - __{leftthreearrows}
+  - '"P{leftthreearrows}"'
   mathml:
   - "&#x2b31;"
   latex:
@@ -7716,7 +7739,7 @@
 - unicodemath:
   - leftthreetimes
   asciimath:
-  - __{leftthreetimes}
+  - '"P{leftthreetimes}"'
   mathml:
   - "&#x22cb;"
   latex:
@@ -7727,12 +7750,12 @@
   - "&#x22cb;"
 - unicodemath:
   - circlearrowleft
-  - __{acwopencirclearrow}
-  - __{leftturn}
+  - '"P{acwopencirclearrow}"'
+  - '"P{leftturn}"'
   asciimath:
-  - __{circlearrowleft}
-  - __{acwopencirclearrow}
-  - __{leftturn}
+  - '"P{circlearrowleft}"'
+  - '"P{acwopencirclearrow}"'
+  - '"P{leftturn}"'
   mathml:
   - "&#x21ba;"
   latex:
@@ -7744,11 +7767,11 @@
   html:
   - "&#x21ba;"
 - unicodemath:
-  - __{updownharpoonleftleft}
-  - __{leftupdownharpoon}
+  - '"P{updownharpoonleftleft}"'
+  - '"P{leftupdownharpoon}"'
   asciimath:
-  - __{updownharpoonleftleft}
-  - __{leftupdownharpoon}
+  - '"P{updownharpoonleftleft}"'
+  - '"P{leftupdownharpoon}"'
   mathml:
   - "&#x2951;"
   latex:
@@ -7759,11 +7782,11 @@
   html:
   - "&#x2951;"
 - unicodemath:
-  - __{upharpoonleftbar}
-  - __{LeftUpTeeVector}
+  - '"P{upharpoonleftbar}"'
+  - '"P{LeftUpTeeVector}"'
   asciimath:
-  - __{upharpoonleftbar}
-  - __{LeftUpTeeVector}
+  - '"P{upharpoonleftbar}"'
+  - '"P{LeftUpTeeVector}"'
   mathml:
   - "&#x2960;"
   latex:
@@ -7774,11 +7797,11 @@
   html:
   - "&#x2960;"
 - unicodemath:
-  - __{barupharpoonleft}
-  - __{LeftUpVectorBar}
+  - '"P{barupharpoonleft}"'
+  - '"P{LeftUpVectorBar}"'
   asciimath:
-  - __{barupharpoonleft}
-  - __{LeftUpVectorBar}
+  - '"P{barupharpoonleft}"'
+  - '"P{LeftUpVectorBar}"'
   mathml:
   - "&#x2958;"
   latex:
@@ -7789,11 +7812,11 @@
   html:
   - "&#x2958;"
 - unicodemath:
-  - __{barleftharpoonup}
-  - __{LeftVectorBar}
+  - '"P{barleftharpoonup}"'
+  - '"P{LeftVectorBar}"'
   asciimath:
-  - __{barleftharpoonup}
-  - __{LeftVectorBar}
+  - '"P{barleftharpoonup}"'
+  - '"P{LeftVectorBar}"'
   mathml:
   - "&#x2952;"
   latex:
@@ -7806,7 +7829,7 @@
 - unicodemath:
   - leftwavearrow
   asciimath:
-  - __{leftwavearrow}
+  - '"P{leftwavearrow}"'
   mathml:
   - "&#x219c;"
   latex:
@@ -7816,9 +7839,9 @@
   html:
   - "&#x219c;"
 - unicodemath:
-  - __{leftwhitearrow}
+  - '"P{leftwhitearrow}"'
   asciimath:
-  - __{leftwhitearrow}
+  - '"P{leftwhitearrow}"'
   mathml:
   - "&#x21e6;"
   latex:
@@ -7828,11 +7851,11 @@
   html:
   - "&#x21e6;"
 - unicodemath:
-  - __{leo}
-  - __{Leo}
+  - '"P{leo}"'
+  - '"P{Leo}"'
   asciimath:
-  - __{leo}
-  - __{Leo}
+  - '"P{leo}"'
+  - '"P{Leo}"'
   mathml:
   - "&#x264c;"
   latex:
@@ -7845,17 +7868,17 @@
 - unicodemath:
   - le
   - leq
-  - __{<=}
+  - '"P{<=}"'
   asciimath:
   - "<="
   - le
-  - __{leq}
+  - '"P{leq}"'
   mathml:
   - "&#x2264;"
   latex:
   - leq
   - le
-  - __{<=}
+  - "\\text{P[<=]}"
   omml:
   - "&#x2264;"
   html:
@@ -7863,7 +7886,7 @@
 - unicodemath:
   - leqq
   asciimath:
-  - __{leqq}
+  - '"P{leqq}"'
   mathml:
   - "&#x2266;"
   latex:
@@ -7873,9 +7896,9 @@
   html:
   - "&#x2266;"
 - unicodemath:
-  - __{leqqslant}
+  - '"P{leqqslant}"'
   asciimath:
-  - __{leqqslant}
+  - '"P{leqqslant}"'
   mathml:
   - "&#x2af9;"
   latex:
@@ -7885,9 +7908,9 @@
   html:
   - "&#x2af9;"
 - unicodemath:
-  - __{leqslant}
+  - '"P{leqslant}"'
   asciimath:
-  - __{leqslant}
+  - '"P{leqslant}"'
   mathml:
   - "&#x2a7d;"
   latex:
@@ -7897,9 +7920,9 @@
   html:
   - "&#x2a7d;"
 - unicodemath:
-  - __{lescc}
+  - '"P{lescc}"'
   asciimath:
-  - __{lescc}
+  - '"P{lescc}"'
   mathml:
   - "&#x2aa8;"
   latex:
@@ -7909,9 +7932,9 @@
   html:
   - "&#x2aa8;"
 - unicodemath:
-  - __{lesdot}
+  - '"P{lesdot}"'
   asciimath:
-  - __{lesdot}
+  - '"P{lesdot}"'
   mathml:
   - "&#x2a7f;"
   latex:
@@ -7921,9 +7944,9 @@
   html:
   - "&#x2a7f;"
 - unicodemath:
-  - __{lesdoto}
+  - '"P{lesdoto}"'
   asciimath:
-  - __{lesdoto}
+  - '"P{lesdoto}"'
   mathml:
   - "&#x2a81;"
   latex:
@@ -7933,9 +7956,9 @@
   html:
   - "&#x2a81;"
 - unicodemath:
-  - __{lesdotor}
+  - '"P{lesdotor}"'
   asciimath:
-  - __{lesdotor}
+  - '"P{lesdotor}"'
   mathml:
   - "&#x2a83;"
   latex:
@@ -7945,9 +7968,9 @@
   html:
   - "&#x2a83;"
 - unicodemath:
-  - __{lesges}
+  - '"P{lesges}"'
   asciimath:
-  - __{lesges}
+  - '"P{lesges}"'
   mathml:
   - "&#x2a93;"
   latex:
@@ -7958,29 +7981,29 @@
   - "&#x2a93;"
 - unicodemath:
   - "&lt;"
-  - __{<}
-  - __{lt}
-  - __{less}
+  - '"P{<}"'
+  - '"P{lt}"'
+  - '"P{less}"'
   asciimath:
   - "<"
   - lt
   - "&lt;"
-  - __{less}
+  - '"P{less}"'
   mathml:
   - "&lt;"
   latex:
   - less
   - "<"
   - "&lt;"
-  - __{lt}
+  - "\\text{P[lt]}"
   omml:
   - "&lt;"
   html:
   - "&#x3c;"
 - unicodemath:
-  - __{lessapprox}
+  - '"P{lessapprox}"'
   asciimath:
-  - __{lessapprox}
+  - '"P{lessapprox}"'
   mathml:
   - "&#x2a85;"
   latex:
@@ -7992,7 +8015,7 @@
 - unicodemath:
   - lessdot
   asciimath:
-  - __{lessdot}
+  - '"P{lessdot}"'
   mathml:
   - "&#x22d6;"
   latex:
@@ -8004,7 +8027,7 @@
 - unicodemath:
   - lesseqgtr
   asciimath:
-  - __{lesseqgtr}
+  - '"P{lesseqgtr}"'
   mathml:
   - "&#x22da;"
   latex:
@@ -8014,9 +8037,9 @@
   html:
   - "&#x22da;"
 - unicodemath:
-  - __{lesseqqgtr}
+  - '"P{lesseqqgtr}"'
   asciimath:
-  - __{lesseqqgtr}
+  - '"P{lesseqqgtr}"'
   mathml:
   - "&#x2a8b;"
   latex:
@@ -8028,7 +8051,7 @@
 - unicodemath:
   - lessgtr
   asciimath:
-  - __{lessgtr}
+  - '"P{lessgtr}"'
   mathml:
   - "&#x2276;"
   latex:
@@ -8038,9 +8061,9 @@
   html:
   - "&#x2276;"
 - unicodemath:
-  - __{lfbowtie}
+  - '"P{lfbowtie}"'
   asciimath:
-  - __{lfbowtie}
+  - '"P{lfbowtie}"'
   mathml:
   - "&#x29d1;"
   latex:
@@ -8050,9 +8073,9 @@
   html:
   - "&#x29d1;"
 - unicodemath:
-  - __{lftimes}
+  - '"P{lftimes}"'
   asciimath:
-  - __{lftimes}
+  - '"P{lftimes}"'
   mathml:
   - "&#x29d4;"
   latex:
@@ -8062,9 +8085,9 @@
   html:
   - "&#x29d4;"
 - unicodemath:
-  - __{lgblkcircle}
+  - '"P{lgblkcircle}"'
   asciimath:
-  - __{lgblkcircle}
+  - '"P{lgblkcircle}"'
   mathml:
   - "&#x2b24;"
   latex:
@@ -8074,9 +8097,9 @@
   html:
   - "&#x2b24;"
 - unicodemath:
-  - __{lgblksquare}
+  - '"P{lgblksquare}"'
   asciimath:
-  - __{lgblksquare}
+  - '"P{lgblksquare}"'
   mathml:
   - "&#x2b1b;"
   latex:
@@ -8086,9 +8109,9 @@
   html:
   - "&#x2b1b;"
 - unicodemath:
-  - __{lgE}
+  - '"P{lgE}"'
   asciimath:
-  - __{lgE}
+  - '"P{lgE}"'
   mathml:
   - "&#x2a91;"
   latex:
@@ -8098,9 +8121,9 @@
   html:
   - "&#x2a91;"
 - unicodemath:
-  - __{lgroup}
+  - '"P{lgroup}"'
   asciimath:
-  - __{lgroup}
+  - '"P{lgroup}"'
   mathml:
   - "&#x27ee;"
   latex:
@@ -8110,9 +8133,9 @@
   html:
   - "&#x27ee;"
 - unicodemath:
-  - __{lgwhtcircle}
+  - '"P{lgwhtcircle}"'
   asciimath:
-  - __{lgwhtcircle}
+  - '"P{lgwhtcircle}"'
   mathml:
   - "&#x25ef;"
   latex:
@@ -8122,9 +8145,9 @@
   html:
   - "&#x25ef;"
 - unicodemath:
-  - __{lgwhtsquare}
+  - '"P{lgwhtsquare}"'
   asciimath:
-  - __{lgwhtsquare}
+  - '"P{lgwhtsquare}"'
   mathml:
   - "&#x2b1c;"
   latex:
@@ -8134,13 +8157,13 @@
   html:
   - "&#x2b1c;"
 - unicodemath:
-  - __{triangleleft}
-  - __{dres}
-  - __{lhd}
+  - '"P{triangleleft}"'
+  - '"P{dres}"'
+  - '"P{lhd}"'
   asciimath:
-  - __{triangleleft}
-  - __{dres}
-  - __{lhd}
+  - '"P{triangleleft}"'
+  - '"P{dres}"'
+  - '"P{lhd}"'
   mathml:
   - "&#x25c1;"
   latex:
@@ -8152,11 +8175,11 @@
   html:
   - "&#x25c1;"
 - unicodemath:
-  - __{libra}
-  - __{Libra}
+  - '"P{libra}"'
+  - '"P{Libra}"'
   asciimath:
-  - __{libra}
-  - __{Libra}
+  - '"P{libra}"'
+  - '"P{Libra}"'
   mathml:
   - "&#x264e;"
   latex:
@@ -8167,11 +8190,11 @@
   html:
   - "&#x264e;"
 - unicodemath:
-  - __{downzigzagarrow}
-  - __{lightning}
+  - '"P{downzigzagarrow}"'
+  - '"P{lightning}"'
   asciimath:
-  - __{downzigzagarrow}
-  - __{lightning}
+  - '"P{downzigzagarrow}"'
+  - '"P{lightning}"'
   mathml:
   - "&#x21af;"
   latex:
@@ -8182,11 +8205,11 @@
   html:
   - "&#x21af;"
 - unicodemath:
-  - __{llparenthesis}
-  - __{limg}
+  - '"P{llparenthesis}"'
+  - '"P{limg}"'
   asciimath:
-  - __{llparenthesis}
-  - __{limg}
+  - '"P{llparenthesis}"'
+  - '"P{limg}"'
   mathml:
   - "&#x2987;"
   latex:
@@ -8197,9 +8220,9 @@
   html:
   - "&#x2987;"
 - unicodemath:
-  - __{linefeed}
+  - '"P{linefeed}"'
   asciimath:
-  - __{linefeed}
+  - '"P{linefeed}"'
   mathml:
   - "&#x21b4;"
   latex:
@@ -8210,20 +8233,23 @@
   - "&#x21b4;"
 - unicodemath:
   - ll
+  - '"P{mlt}"'
   asciimath:
-  - __{ll}
+  - ll
+  - mlt
   mathml:
   - "&#x226a;"
   latex:
   - ll
+  - "\\text{P[mlt]}"
   omml:
   - "&#x226a;"
   html:
   - "&#x226a;"
 - unicodemath:
-  - __{llarc}
+  - '"P{llarc}"'
   asciimath:
-  - __{llarc}
+  - '"P{llarc}"'
   mathml:
   - "&#x25df;"
   latex:
@@ -8233,9 +8259,9 @@
   html:
   - "&#x25df;"
 - unicodemath:
-  - __{llblacktriangle}
+  - '"P{llblacktriangle}"'
   asciimath:
-  - __{llblacktriangle}
+  - '"P{llblacktriangle}"'
   mathml:
   - "&#x25e3;"
   latex:
@@ -8245,9 +8271,9 @@
   html:
   - "&#x25e3;"
 - unicodemath:
-  - __{llcorner}
+  - '"P{llcorner}"'
   asciimath:
-  - __{llcorner}
+  - '"P{llcorner}"'
   mathml:
   - "&#x231e;"
   latex:
@@ -8257,9 +8283,9 @@
   html:
   - "&#x231e;"
 - unicodemath:
-  - __{LLeftarrow}
+  - '"P{LLeftarrow}"'
   asciimath:
-  - __{LLeftarrow}
+  - '"P{LLeftarrow}"'
   mathml:
   - "&#x2b45;"
   latex:
@@ -8269,9 +8295,9 @@
   html:
   - "&#x2b45;"
 - unicodemath:
-  - __{lll}
+  - '"P{lll}"'
   asciimath:
-  - __{lll}
+  - '"P{lll}"'
   mathml:
   - "&#x22d8;"
   latex:
@@ -8281,9 +8307,9 @@
   html:
   - "&#x22d8;"
 - unicodemath:
-  - __{lllnest}
+  - '"P{lllnest}"'
   asciimath:
-  - __{lllnest}
+  - '"P{lllnest}"'
   mathml:
   - "&#x2af7;"
   latex:
@@ -8293,9 +8319,9 @@
   html:
   - "&#x2af7;"
 - unicodemath:
-  - __{lltriangle}
+  - '"P{lltriangle}"'
   asciimath:
-  - __{lltriangle}
+  - '"P{lltriangle}"'
   mathml:
   - "&#x25fa;"
   latex:
@@ -8306,23 +8332,23 @@
   - "&#x25fa;"
 - unicodemath:
   - lmoust
-  - __{prurel}
+  - '"P{prurel}"'
   asciimath:
-  - __{lmoust}
-  - __{prurel}
+  - '"P{lmoust}"'
+  - '"P{prurel}"'
   mathml:
   - "&#x22b0;"
   latex:
   - prurel
-  - __{lmoust}
+  - "\\text{P[lmoust]}"
   omml:
   - "&#x22b0;"
   html:
   - "&#x22b0;"
 - unicodemath:
-  - __{lmoustache}
+  - '"P{lmoustache}"'
   asciimath:
-  - __{lmoustache}
+  - '"P{lmoustache}"'
   mathml:
   - "&#x23b0;"
   latex:
@@ -8332,9 +8358,9 @@
   html:
   - "&#x23b0;"
 - unicodemath:
-  - __{lnapprox}
+  - '"P{lnapprox}"'
   asciimath:
-  - __{lnapprox}
+  - '"P{lnapprox}"'
   mathml:
   - "&#x2a89;"
   latex:
@@ -8345,36 +8371,38 @@
   - "&#x2a89;"
 - unicodemath:
   - lneq
-  - __{lneqq}
+  - '"P{lneqq}"'
   asciimath:
-  - __{lneq}
-  - __{lneqq}
+  - '"P{lneq}"'
+  - '"P{lneqq}"'
   mathml:
   - "&#x2268;"
   latex:
   - lneqq
-  - __{lneq}
+  - "\\text{P[lneq]}"
   omml:
   - "&#x2268;"
   html:
   - "&#x2268;"
 - unicodemath:
   - lnot
-  - __{not}
+  - '"P{not}"'
   asciimath:
   - not
-  - __{lnot}
+  - '"P{lnot}"'
   mathml:
   - "&#xac;"
   latex:
   - lnot
-  - __{not}
+  - "\\text{P[not]}"
+  html:
+  - "&#xac;"
   omml:
   - "&#xac;"
 - unicodemath:
   - lnsim
   asciimath:
-  - __{lnsim}
+  - '"P{lnsim}"'
   mathml:
   - "&#x22e6;"
   latex:
@@ -8384,9 +8412,9 @@
   html:
   - "&#x22e6;"
 - unicodemath:
-  - __{longdashv}
+  - '"P{longdashv}"'
   asciimath:
-  - __{longdashv}
+  - '"P{longdashv}"'
   mathml:
   - "&#x27de;"
   latex:
@@ -8396,9 +8424,9 @@
   html:
   - "&#x27de;"
 - unicodemath:
-  - __{longdivision}
+  - '"P{longdivision}"'
   asciimath:
-  - __{longdivision}
+  - '"P{longdivision}"'
   mathml:
   - "&#x27cc;"
   latex:
@@ -8410,7 +8438,7 @@
 - unicodemath:
   - longleftarrow
   asciimath:
-  - __{longleftarrow}
+  - '"P{longleftarrow}"'
   mathml:
   - "&#x27f5;"
   latex:
@@ -8421,10 +8449,10 @@
   - "&#x27f5;"
 - unicodemath:
   - Longleftrightarrow
-  - __{iff}
+  - '"P{iff}"'
   asciimath:
-  - __{Longleftrightarrow}
-  - __{iff}
+  - '"P{Longleftrightarrow}"'
+  - '"P{iff}"'
   mathml:
   - "&#x27fa;"
   latex:
@@ -8435,9 +8463,9 @@
   html:
   - "&#x27fa;"
 - unicodemath:
-  - __{longleftsquigarrow}
+  - '"P{longleftsquigarrow}"'
   asciimath:
-  - __{longleftsquigarrow}
+  - '"P{longleftsquigarrow}"'
   mathml:
   - "&#x2b33;"
   latex:
@@ -8447,11 +8475,11 @@
   html:
   - "&#x2b33;"
 - unicodemath:
-  - __{Longmappedfrom}
-  - __{Longmapsfrom}
+  - '"P{Longmappedfrom}"'
+  - '"P{Longmapsfrom}"'
   asciimath:
-  - __{Longmappedfrom}
-  - __{Longmapsfrom}
+  - '"P{Longmappedfrom}"'
+  - '"P{Longmapsfrom}"'
   mathml:
   - "&#x27fd;"
   latex:
@@ -8462,9 +8490,9 @@
   html:
   - "&#x27fd;"
 - unicodemath:
-  - __{Longmapsto}
+  - '"P{Longmapsto}"'
   asciimath:
-  - __{Longmapsto}
+  - '"P{Longmapsto}"'
   mathml:
   - "&#x27fe;"
   latex:
@@ -8475,10 +8503,10 @@
   - "&#x27fe;"
 - unicodemath:
   - Longrightarrow
-  - __{implies}
+  - '"P{implies}"'
   asciimath:
-  - __{Longrightarrow}
-  - __{implies}
+  - '"P{Longrightarrow}"'
+  - '"P{implies}"'
   mathml:
   - "&#x27f9;"
   latex:
@@ -8490,41 +8518,41 @@
   - "&#x27f9;"
 - unicodemath:
   - looparrowleft
-  - __{looparrowright}
+  - '"P{looparrowright}"'
   asciimath:
-  - __{looparrowleft}
-  - __{looparrowright}
+  - '"P{looparrowleft}"'
+  - '"P{looparrowright}"'
   mathml:
   - "&#x21ac;"
   latex:
   - looparrowright
-  - __{looparrowleft}
+  - "\\text{P[looparrowleft]}"
   omml:
   - "&#x21ac;"
   html:
   - "&#x21ac;"
 - unicodemath:
   - lor
-  - __{vee}
-  - __{vv}
+  - '"P{vee}"'
+  - '"P{vv}"'
   asciimath:
   - vee
   - vv
-  - __{lor}
+  - '"P{lor}"'
   mathml:
   - "&#x2228;"
   latex:
   - vee
   - lor
-  - __{vv}
+  - "\\text{P[vv]}"
   omml:
   - "&#x2228;"
   html:
   - "&#x2228;"
 - unicodemath:
-  - __{lowint}
+  - '"P{lowint}"'
   asciimath:
-  - __{lowint}
+  - '"P{lowint}"'
   mathml:
   - "&#x2a1c;"
   latex:
@@ -8534,11 +8562,11 @@
   html:
   - "&#x2a1c;"
 - unicodemath:
-  - __{mdlgwhtlozenge}
-  - __{lozenge}
+  - '"P{mdlgwhtlozenge}"'
+  - '"P{lozenge}"'
   asciimath:
-  - __{mdlgwhtlozenge}
-  - __{lozenge}
+  - '"P{mdlgwhtlozenge}"'
+  - '"P{lozenge}"'
   mathml:
   - "&#x25ca;"
   latex:
@@ -8549,9 +8577,9 @@
   html:
   - "&#x25ca;"
 - unicodemath:
-  - __{lozengeminus}
+  - '"P{lozengeminus}"'
   asciimath:
-  - __{lozengeminus}
+  - '"P{lozengeminus}"'
   mathml:
   - "&#x27e0;"
   latex:
@@ -8561,9 +8589,9 @@
   html:
   - "&#x27e0;"
 - unicodemath:
-  - __{lparen}
+  - '"P{lparen}"'
   asciimath:
-  - __{lparen}
+  - '"P{lparen}"'
   mathml:
   - "&#x28;"
   latex:
@@ -8573,9 +8601,9 @@
   html:
   - "&#x28;"
 - unicodemath:
-  - __{lparenextender}
+  - '"P{lparenextender}"'
   asciimath:
-  - __{lparenextender}
+  - '"P{lparenextender}"'
   mathml:
   - "&#x239c;"
   latex:
@@ -8585,9 +8613,9 @@
   html:
   - "&#x239c;"
 - unicodemath:
-  - __{Lparengtr}
+  - '"P{Lparengtr}"'
   asciimath:
-  - __{Lparengtr}
+  - '"P{Lparengtr}"'
   mathml:
   - "&#x2995;"
   latex:
@@ -8597,9 +8625,9 @@
   html:
   - "&#x2995;"
 - unicodemath:
-  - __{lparenlend}
+  - '"P{lparenlend}"'
   asciimath:
-  - __{lparenlend}
+  - '"P{lparenlend}"'
   mathml:
   - "&#x239d;"
   latex:
@@ -8609,9 +8637,9 @@
   html:
   - "&#x239d;"
 - unicodemath:
-  - __{lparenless}
+  - '"P{lparenless}"'
   asciimath:
-  - __{lparenless}
+  - '"P{lparenless}"'
   mathml:
   - "&#x2993;"
   latex:
@@ -8621,9 +8649,9 @@
   html:
   - "&#x2993;"
 - unicodemath:
-  - __{lparenuend}
+  - '"P{lparenuend}"'
   asciimath:
-  - __{lparenuend}
+  - '"P{lparenuend}"'
   mathml:
   - "&#x239b;"
   latex:
@@ -8633,9 +8661,9 @@
   html:
   - "&#x239b;"
 - unicodemath:
-  - __{lrarc}
+  - '"P{lrarc}"'
   asciimath:
-  - __{lrarc}
+  - '"P{lrarc}"'
   mathml:
   - "&#x25de;"
   latex:
@@ -8645,9 +8673,9 @@
   html:
   - "&#x25de;"
 - unicodemath:
-  - __{lrblacktriangle}
+  - '"P{lrblacktriangle}"'
   asciimath:
-  - __{lrblacktriangle}
+  - '"P{lrblacktriangle}"'
   mathml:
   - "&#x25e2;"
   latex:
@@ -8657,9 +8685,9 @@
   html:
   - "&#x25e2;"
 - unicodemath:
-  - __{lrcorner}
+  - '"P{lrcorner}"'
   asciimath:
-  - __{lrcorner}
+  - '"P{lrcorner}"'
   mathml:
   - "&#x231f;"
   latex:
@@ -8671,43 +8699,43 @@
 - unicodemath:
   - leftrightharpoons
   - lrhar
-  - __{revequilibrium}
+  - '"P{revequilibrium}"'
   asciimath:
-  - __{leftrightharpoons}
-  - __{lrhar}
-  - __{revequilibrium}
+  - '"P{leftrightharpoons}"'
+  - '"P{lrhar}"'
+  - '"P{revequilibrium}"'
   mathml:
   - "&#x21cb;"
   latex:
   - leftrightharpoons
   - revequilibrium
-  - __{lrhar}
+  - "\\text{P[lrhar]}"
   omml:
   - "&#x21cb;"
   html:
   - "&#x21cb;"
 - unicodemath:
   - bowtie
-  - __{|><|}
-  - __{lrtimes}
+  - '"P{|><|}"'
+  - '"P{lrtimes}"'
   asciimath:
   - bowtie
   - "|><|"
-  - __{lrtimes}
+  - '"P{lrtimes}"'
   mathml:
   - "&#x22c8;"
   latex:
   - lrtimes
   - bowtie
-  - __{|><|}
+  - "\\text{P[|><|]}"
   omml:
   - "&#x22c8;"
   html:
   - "&#x22c8;"
 - unicodemath:
-  - __{lrtriangle}
+  - '"P{lrtriangle}"'
   asciimath:
-  - __{lrtriangle}
+  - '"P{lrtriangle}"'
   mathml:
   - "&#x25ff;"
   latex:
@@ -8717,9 +8745,9 @@
   html:
   - "&#x25ff;"
 - unicodemath:
-  - __{lrtriangleeq}
+  - '"P{lrtriangleeq}"'
   asciimath:
-  - __{lrtriangleeq}
+  - '"P{lrtriangleeq}"'
   mathml:
   - "&#x29e1;"
   latex:
@@ -8729,9 +8757,9 @@
   html:
   - "&#x29e1;"
 - unicodemath:
-  - __{Lsh}
+  - '"P{Lsh}"'
   asciimath:
-  - __{Lsh}
+  - '"P{Lsh}"'
   mathml:
   - "&#x21b0;"
   latex:
@@ -8741,9 +8769,9 @@
   html:
   - "&#x21b0;"
 - unicodemath:
-  - __{lsime}
+  - '"P{lsime}"'
   asciimath:
-  - __{lsime}
+  - '"P{lsime}"'
   mathml:
   - "&#x2a8d;"
   latex:
@@ -8753,9 +8781,9 @@
   html:
   - "&#x2a8d;"
 - unicodemath:
-  - __{lsimg}
+  - '"P{lsimg}"'
   asciimath:
-  - __{lsimg}
+  - '"P{lsimg}"'
   mathml:
   - "&#x2a8f;"
   latex:
@@ -8765,9 +8793,9 @@
   html:
   - "&#x2a8f;"
 - unicodemath:
-  - __{lsqhook}
+  - '"P{lsqhook}"'
   asciimath:
-  - __{lsqhook}
+  - '"P{lsqhook}"'
   mathml:
   - "&#x2acd;"
   latex:
@@ -8778,31 +8806,31 @@
   - "&#x2acd;"
 - unicodemath:
   - "&lt;"
-  - __{<}
-  - __{lt}
-  - __{less}
+  - '"P{<}"'
+  - '"P{lt}"'
+  - '"P{less}"'
   asciimath:
   - "<"
   - lt
   - "&lt;"
-  - __{less}
+  - '"P{less}"'
   mathml:
   - "&lt;"
   latex:
   - less
   - "<"
   - "&lt;"
-  - __{lt}
+  - "\\text{P[lt]}"
   omml:
   - "&lt;"
   html:
   - "&#x3c;"
 - unicodemath:
-  - __{leftslice}
-  - __{ltcc}
+  - '"P{leftslice}"'
+  - '"P{ltcc}"'
   asciimath:
-  - __{leftslice}
-  - __{ltcc}
+  - '"P{leftslice}"'
+  - '"P{ltcc}"'
   mathml:
   - "&#x2aa6;"
   latex:
@@ -8813,9 +8841,9 @@
   html:
   - "&#x2aa6;"
 - unicodemath:
-  - __{ltcir}
+  - '"P{ltcir}"'
   asciimath:
-  - __{ltcir}
+  - '"P{ltcir}"'
   mathml:
   - "&#x2a79;"
   latex:
@@ -8826,7 +8854,7 @@
   - "&#x2a79;"
 - unicodemath:
   - ltimes
-  - __{|><}
+  - '"P{|><}"'
   asciimath:
   - ltimes
   - "|><"
@@ -8834,15 +8862,15 @@
   - "&#x22c9;"
   latex:
   - ltimes
-  - __{|><}
+  - "\\text{P[|><]}"
   omml:
   - "&#x22c9;"
   html:
   - "&#x22c9;"
 - unicodemath:
-  - __{ltlarr}
+  - '"P{ltlarr}"'
   asciimath:
-  - __{ltlarr}
+  - '"P{ltlarr}"'
   mathml:
   - "&#x2976;"
   latex:
@@ -8852,9 +8880,9 @@
   html:
   - "&#x2976;"
 - unicodemath:
-  - __{ltquest}
+  - '"P{ltquest}"'
   asciimath:
-  - __{ltquest}
+  - '"P{ltquest}"'
   mathml:
   - "&#x2a7b;"
   latex:
@@ -8864,11 +8892,11 @@
   html:
   - "&#x2a7b;"
 - unicodemath:
-  - __{LeftTriangleBar}
-  - __{ltrivb}
+  - '"P{LeftTriangleBar}"'
+  - '"P{ltrivb}"'
   asciimath:
-  - __{LeftTriangleBar}
-  - __{ltrivb}
+  - '"P{LeftTriangleBar}"'
+  - '"P{ltrivb}"'
   mathml:
   - "&#x29cf;"
   latex:
@@ -8879,9 +8907,9 @@
   html:
   - "&#x29cf;"
 - unicodemath:
-  - __{lvboxline}
+  - '"P{lvboxline}"'
   asciimath:
-  - __{lvboxline}
+  - '"P{lvboxline}"'
   mathml:
   - "&#x23b8;"
   latex:
@@ -8891,11 +8919,11 @@
   html:
   - "&#x23b8;"
 - unicodemath:
-  - __{overleftarrow}
-  - __{LVec}
+  - '"P{overleftarrow}"'
+  - '"P{LVec}"'
   asciimath:
-  - __{overleftarrow}
-  - __{LVec}
+  - '"P{overleftarrow}"'
+  - '"P{LVec}"'
   mathml:
   - "&#x20d6;"
   latex:
@@ -8906,9 +8934,9 @@
   html:
   - "&#x20d6;"
 - unicodemath:
-  - __{Lvzigzag}
+  - '"P{Lvzigzag}"'
   asciimath:
-  - __{Lvzigzag}
+  - '"P{Lvzigzag}"'
   mathml:
   - "&#x29da;"
   latex:
@@ -8918,9 +8946,9 @@
   html:
   - "&#x29da;"
 - unicodemath:
-  - __{maltese}
+  - '"P{maltese}"'
   asciimath:
-  - __{maltese}
+  - '"P{maltese}"'
   mathml:
   - "&#x2720;"
   latex:
@@ -8930,11 +8958,11 @@
   html:
   - "&#x2720;"
 - unicodemath:
-  - __{MapsDown}
-  - __{mapsdown}
+  - '"P{MapsDown}"'
+  - '"P{mapsdown}"'
   asciimath:
-  - __{MapsDown}
-  - __{mapsdown}
+  - '"P{MapsDown}"'
+  - '"P{mapsdown}"'
   mathml:
   - "&#x21a7;"
   latex:
@@ -8945,11 +8973,11 @@
   html:
   - "&#x21a7;"
 - unicodemath:
-  - __{Mappedfrom}
-  - __{Mapsfrom}
+  - '"P{Mappedfrom}"'
+  - '"P{Mapsfrom}"'
   asciimath:
-  - __{Mappedfrom}
-  - __{Mapsfrom}
+  - '"P{Mappedfrom}"'
+  - '"P{Mapsfrom}"'
   mathml:
   - "&#x2906;"
   latex:
@@ -8961,7 +8989,7 @@
   - "&#x2906;"
 - unicodemath:
   - mapsto
-  - __{|->}
+  - '"P{|->}"'
   asciimath:
   - mapsto
   - "|->"
@@ -8969,35 +8997,35 @@
   - "&#x21a6;"
   latex:
   - mapsto
-  - __{|->}
+  - "\\text{P[|->]}"
   omml:
   - "&#x21a6;"
   html:
   - "&#x21a6;"
 - unicodemath:
   - mapstoleft
-  - __{mappedfrom}
-  - __{mapsfrom}
+  - '"P{mappedfrom}"'
+  - '"P{mapsfrom}"'
   asciimath:
-  - __{mapstoleft}
-  - __{mappedfrom}
-  - __{mapsfrom}
+  - '"P{mapstoleft}"'
+  - '"P{mappedfrom}"'
+  - '"P{mapsfrom}"'
   mathml:
   - "&#x21a4;"
   latex:
   - mappedfrom
   - mapsfrom
-  - __{mapstoleft}
+  - "\\text{P[mapstoleft]}"
   omml:
   - "&#x21a4;"
   html:
   - "&#x21a4;"
 - unicodemath:
-  - __{MapsUp}
-  - __{mapsup}
+  - '"P{MapsUp}"'
+  - '"P{mapsup}"'
   asciimath:
-  - __{MapsUp}
-  - __{mapsup}
+  - '"P{MapsUp}"'
+  - '"P{mapsup}"'
   mathml:
   - "&#x21a5;"
   latex:
@@ -9008,11 +9036,11 @@
   html:
   - "&#x21a5;"
 - unicodemath:
-  - __{male}
-  - __{Mars}
+  - '"P{male}"'
+  - '"P{Mars}"'
   asciimath:
-  - __{male}
-  - __{Mars}
+  - '"P{male}"'
+  - '"P{Mars}"'
   mathml:
   - "&#x2642;"
   latex:
@@ -9023,13 +9051,13 @@
   html:
   - "&#x2642;"
 - unicodemath:
-  - __{:}
-  - __{mathcolon}
-  - __{colon}
+  - '"P{:}"'
+  - '"P{mathcolon}"'
+  - '"P{colon}"'
   asciimath:
   - ":"
-  - __{mathcolon}
-  - __{colon}
+  - '"P{mathcolon}"'
+  - '"P{colon}"'
   mathml:
   - "&#x3a;"
   latex:
@@ -9041,11 +9069,11 @@
   html:
   - "&#x3a;"
 - unicodemath:
-  - __{$}
-  - __{mathdollar}
+  - '"P{$}"'
+  - '"P{mathdollar}"'
   asciimath:
   - "$"
-  - __{mathdollar}
+  - '"P{mathdollar}"'
   mathml:
   - "&#x24;"
   latex:
@@ -9056,11 +9084,11 @@
   html:
   - "&#x24;"
 - unicodemath:
-  - __{//}
-  - __{mathslash}
+  - '"P{//}"'
+  - '"P{mathslash}"'
   asciimath:
   - "//"
-  - __{mathslash}
+  - '"P{mathslash}"'
   mathml:
   - "&#x2f;"
   latex:
@@ -9071,9 +9099,9 @@
   html:
   - "&#x2f;"
 - unicodemath:
-  - __{mdblkdiamond}
+  - '"P{mdblkdiamond}"'
   asciimath:
-  - __{mdblkdiamond}
+  - '"P{mdblkdiamond}"'
   mathml:
   - "&#x2b25;"
   latex:
@@ -9083,9 +9111,9 @@
   html:
   - "&#x2b25;"
 - unicodemath:
-  - __{mdblklozenge}
+  - '"P{mdblklozenge}"'
   asciimath:
-  - __{mdblklozenge}
+  - '"P{mdblklozenge}"'
   mathml:
   - "&#x2b27;"
   latex:
@@ -9095,11 +9123,11 @@
   html:
   - "&#x2b27;"
 - unicodemath:
-  - __{blacksquare}
-  - __{mdblksquare}
+  - '"P{blacksquare}"'
+  - '"P{mdblksquare}"'
   asciimath:
-  - __{blacksquare}
-  - __{mdblksquare}
+  - '"P{blacksquare}"'
+  - '"P{mdblksquare}"'
   mathml:
   - "&#x25fc;"
   latex:
@@ -9110,9 +9138,9 @@
   html:
   - "&#x25fc;"
 - unicodemath:
-  - __{mdlgblksquare}
+  - '"P{mdlgblksquare}"'
   asciimath:
-  - __{mdlgblksquare}
+  - '"P{mdlgblksquare}"'
   mathml:
   - "&#x25a0;"
   latex:
@@ -9122,9 +9150,9 @@
   html:
   - "&#x25a0;"
 - unicodemath:
-  - __{mdsmblksquare}
+  - '"P{mdsmblksquare}"'
   asciimath:
-  - __{mdsmblksquare}
+  - '"P{mdsmblksquare}"'
   mathml:
   - "&#x25fe;"
   latex:
@@ -9134,9 +9162,9 @@
   html:
   - "&#x25fe;"
 - unicodemath:
-  - __{mdsmwhtcircle}
+  - '"P{mdsmwhtcircle}"'
   asciimath:
-  - __{mdsmwhtcircle}
+  - '"P{mdsmwhtcircle}"'
   mathml:
   - "&#x26ac;"
   latex:
@@ -9146,9 +9174,9 @@
   html:
   - "&#x26ac;"
 - unicodemath:
-  - __{mdsmwhtsquare}
+  - '"P{mdsmwhtsquare}"'
   asciimath:
-  - __{mdsmwhtsquare}
+  - '"P{mdsmwhtsquare}"'
   mathml:
   - "&#x25fd;"
   latex:
@@ -9158,9 +9186,9 @@
   html:
   - "&#x25fd;"
 - unicodemath:
-  - __{mdwhtdiamond}
+  - '"P{mdwhtdiamond}"'
   asciimath:
-  - __{mdwhtdiamond}
+  - '"P{mdwhtdiamond}"'
   mathml:
   - "&#x2b26;"
   latex:
@@ -9170,9 +9198,9 @@
   html:
   - "&#x2b26;"
 - unicodemath:
-  - __{mdwhtlozenge}
+  - '"P{mdwhtlozenge}"'
   asciimath:
-  - __{mdwhtlozenge}
+  - '"P{mdwhtlozenge}"'
   mathml:
   - "&#x2b28;"
   latex:
@@ -9182,11 +9210,11 @@
   html:
   - "&#x2b28;"
 - unicodemath:
-  - __{mdwhtsquare}
-  - __{square}
+  - '"P{mdwhtsquare}"'
+  - '"P{square}"'
   asciimath:
-  - __{mdwhtsquare}
-  - __{square}
+  - '"P{mdwhtsquare}"'
+  - '"P{square}"'
   mathml:
   - "&#x25fb;"
   latex:
@@ -9197,9 +9225,9 @@
   html:
   - "&#x25fb;"
 - unicodemath:
-  - __{measangledltosw}
+  - '"P{measangledltosw}"'
   asciimath:
-  - __{measangledltosw}
+  - '"P{measangledltosw}"'
   mathml:
   - "&#x29af;"
   latex:
@@ -9209,9 +9237,9 @@
   html:
   - "&#x29af;"
 - unicodemath:
-  - __{measangledrtose}
+  - '"P{measangledrtose}"'
   asciimath:
-  - __{measangledrtose}
+  - '"P{measangledrtose}"'
   mathml:
   - "&#x29ae;"
   latex:
@@ -9221,9 +9249,9 @@
   html:
   - "&#x29ae;"
 - unicodemath:
-  - __{measangleldtosw}
+  - '"P{measangleldtosw}"'
   asciimath:
-  - __{measangleldtosw}
+  - '"P{measangleldtosw}"'
   mathml:
   - "&#x29ab;"
   latex:
@@ -9233,9 +9261,9 @@
   html:
   - "&#x29ab;"
 - unicodemath:
-  - __{measanglelutonw}
+  - '"P{measanglelutonw}"'
   asciimath:
-  - __{measanglelutonw}
+  - '"P{measanglelutonw}"'
   mathml:
   - "&#x29a9;"
   latex:
@@ -9245,9 +9273,9 @@
   html:
   - "&#x29a9;"
 - unicodemath:
-  - __{measanglerdtose}
+  - '"P{measanglerdtose}"'
   asciimath:
-  - __{measanglerdtose}
+  - '"P{measanglerdtose}"'
   mathml:
   - "&#x29aa;"
   latex:
@@ -9257,9 +9285,9 @@
   html:
   - "&#x29aa;"
 - unicodemath:
-  - __{measanglerutone}
+  - '"P{measanglerutone}"'
   asciimath:
-  - __{measanglerutone}
+  - '"P{measanglerutone}"'
   mathml:
   - "&#x29a8;"
   latex:
@@ -9269,9 +9297,9 @@
   html:
   - "&#x29a8;"
 - unicodemath:
-  - __{measangleultonw}
+  - '"P{measangleultonw}"'
   asciimath:
-  - __{measangleultonw}
+  - '"P{measangleultonw}"'
   mathml:
   - "&#x29ad;"
   latex:
@@ -9281,9 +9309,9 @@
   html:
   - "&#x29ad;"
 - unicodemath:
-  - __{measangleurtone}
+  - '"P{measangleurtone}"'
   asciimath:
-  - __{measangleurtone}
+  - '"P{measangleurtone}"'
   mathml:
   - "&#x29ac;"
   latex:
@@ -9293,9 +9321,9 @@
   html:
   - "&#x29ac;"
 - unicodemath:
-  - __{measeq}
+  - '"P{measeq}"'
   asciimath:
-  - __{measeq}
+  - '"P{measeq}"'
   mathml:
   - "&#x225e;"
   latex:
@@ -9305,9 +9333,9 @@
   html:
   - "&#x225e;"
 - unicodemath:
-  - __{measuredangleleft}
+  - '"P{measuredangleleft}"'
   asciimath:
-  - __{measuredangleleft}
+  - '"P{measuredangleleft}"'
   mathml:
   - "&#x299b;"
   latex:
@@ -9317,9 +9345,9 @@
   html:
   - "&#x299b;"
 - unicodemath:
-  - __{medblackstar}
+  - '"P{medblackstar}"'
   asciimath:
-  - __{medblackstar}
+  - '"P{medblackstar}"'
   mathml:
   - "&#x2b51;"
   latex:
@@ -9329,11 +9357,11 @@
   html:
   - "&#x2b51;"
 - unicodemath:
-  - __{mdblkcircle}
-  - __{medbullet}
+  - '"P{mdblkcircle}"'
+  - '"P{medbullet}"'
   asciimath:
-  - __{mdblkcircle}
-  - __{medbullet}
+  - '"P{mdblkcircle}"'
+  - '"P{medbullet}"'
   mathml:
   - "&#x26ab;"
   latex:
@@ -9344,11 +9372,11 @@
   html:
   - "&#x26ab;"
 - unicodemath:
-  - __{mdwhtcircle}
-  - __{medcirc}
+  - '"P{mdwhtcircle}"'
+  - '"P{medcirc}"'
   asciimath:
-  - __{mdwhtcircle}
-  - __{medcirc}
+  - '"P{mdwhtcircle}"'
+  - '"P{medcirc}"'
   mathml:
   - "&#x26aa;"
   latex:
@@ -9360,23 +9388,23 @@
   - "&#x26aa;"
 - unicodemath:
   - medsp
-  - __{medspace}
+  - '"P{medspace}"'
   asciimath:
-  - __{medsp}
-  - __{medspace}
+  - '"P{medsp}"'
+  - '"P{medspace}"'
   mathml:
   - "&#x205f;"
   latex:
   - medspace
-  - __{medsp}
+  - "\\text{P[medsp]}"
   omml:
   - "&#x205f;"
   html:
   - "&#x205f;"
 - unicodemath:
-  - __{medwhitestar}
+  - '"P{medwhitestar}"'
   asciimath:
-  - __{medwhitestar}
+  - '"P{medwhitestar}"'
   mathml:
   - "&#x2b50;"
   latex:
@@ -9386,11 +9414,11 @@
   html:
   - "&#x2b50;"
 - unicodemath:
-  - __{mercury}
-  - __{Mercury}
+  - '"P{mercury}"'
+  - '"P{Mercury}"'
   asciimath:
-  - __{mercury}
-  - __{Mercury}
+  - '"P{mercury}"'
+  - '"P{Mercury}"'
   mathml:
   - "&#x263f;"
   latex:
@@ -9401,11 +9429,11 @@
   html:
   - "&#x263f;"
 - unicodemath:
-  - __{mho}
-  - __{Mho}
+  - '"P{mho}"'
+  - '"P{Mho}"'
   asciimath:
-  - __{mho}
-  - __{Mho}
+  - '"P{mho}"'
+  - '"P{Mho}"'
   mathml:
   - "&#x2127;"
   latex:
@@ -9416,9 +9444,9 @@
   html:
   - "&#x2127;"
 - unicodemath:
-  - __{mid}
+  - '"P{mid}"'
   asciimath:
-  - __{mid}
+  - '"P{mid}"'
   mathml:
   - "&#x2223;"
   latex:
@@ -9428,9 +9456,9 @@
   html:
   - "&#x2223;"
 - unicodemath:
-  - __{midbarvee}
+  - '"P{midbarvee}"'
   asciimath:
-  - __{midbarvee}
+  - '"P{midbarvee}"'
   mathml:
   - "&#x2a5d;"
   latex:
@@ -9440,9 +9468,9 @@
   html:
   - "&#x2a5d;"
 - unicodemath:
-  - __{midbarwedge}
+  - '"P{midbarwedge}"'
   asciimath:
-  - __{midbarwedge}
+  - '"P{midbarwedge}"'
   mathml:
   - "&#x2a5c;"
   latex:
@@ -9452,9 +9480,9 @@
   html:
   - "&#x2a5c;"
 - unicodemath:
-  - __{midcir}
+  - '"P{midcir}"'
   asciimath:
-  - __{midcir}
+  - '"P{midcir}"'
   mathml:
   - "&#x2af0;"
   latex:
@@ -9465,12 +9493,12 @@
   - "&#x2af0;"
 - unicodemath:
   - "-"
-  - __{minus}
+  - '"P{minus}"'
   asciimath:
   - "-"
-  - __{minus}
+  - '"P{minus}"'
   mathml:
-  - "&#x2212;"
+  - "-"
   latex:
   - minus
   - "-"
@@ -9479,9 +9507,9 @@
   html:
   - "&#x2212;"
 - unicodemath:
-  - __{minusdot}
+  - '"P{minusdot}"'
   asciimath:
-  - __{minusdot}
+  - '"P{minusdot}"'
   mathml:
   - "&#x2a2a;"
   latex:
@@ -9491,9 +9519,9 @@
   html:
   - "&#x2a2a;"
 - unicodemath:
-  - __{minusfdots}
+  - '"P{minusfdots}"'
   asciimath:
-  - __{minusfdots}
+  - '"P{minusfdots}"'
   mathml:
   - "&#x2a2b;"
   latex:
@@ -9503,9 +9531,9 @@
   html:
   - "&#x2a2b;"
 - unicodemath:
-  - __{minusrdots}
+  - '"P{minusrdots}"'
   asciimath:
-  - __{minusrdots}
+  - '"P{minusrdots}"'
   mathml:
   - "&#x2a2c;"
   latex:
@@ -9515,9 +9543,9 @@
   html:
   - "&#x2a2c;"
 - unicodemath:
-  - __{mlcp}
+  - '"P{mlcp}"'
   asciimath:
-  - __{mlcp}
+  - '"P{mlcp}"'
   mathml:
   - "&#x2adb;"
   latex:
@@ -9528,26 +9556,26 @@
   - "&#x2adb;"
 - unicodemath:
   - models
-  - __{|==}
-  - __{vDash}
+  - '"P{|==}"'
+  - '"P{vDash}"'
   asciimath:
   - models
   - "|=="
-  - __{vDash}
+  - '"P{vDash}"'
   mathml:
   - "&#x22a8;"
   latex:
   - vDash
-  - __{models}
-  - __{|==}
+  - "\\text{P[models]}"
+  - "\\text{P[|==]}"
   omml:
   - "&#x22a8;"
   html:
   - "&#x22a8;"
 - unicodemath:
-  - __{modtwosum}
+  - '"P{modtwosum}"'
   asciimath:
-  - __{modtwosum}
+  - '"P{modtwosum}"'
   mathml:
   - "&#x2a0a;"
   latex:
@@ -9559,7 +9587,7 @@
 - unicodemath:
   - mp
   asciimath:
-  - __{mp}
+  - '"P{mp}"'
   mathml:
   - "&#x2213;"
   latex:
@@ -9570,10 +9598,10 @@
   - "&#x2213;"
 - unicodemath:
   - mu
-  - __{upmu}
+  - '"P{upmu}"'
   asciimath:
   - mu
-  - __{upmu}
+  - '"P{upmu}"'
   mathml:
   - "&#x3bc;"
   latex:
@@ -9586,7 +9614,7 @@
 - unicodemath:
   - multimap
   asciimath:
-  - __{multimap}
+  - '"P{multimap}"'
   mathml:
   - "&#x22b8;"
   latex:
@@ -9596,9 +9624,9 @@
   html:
   - "&#x22b8;"
 - unicodemath:
-  - __{multimapinv}
+  - '"P{multimapinv}"'
   asciimath:
-  - __{multimapinv}
+  - '"P{multimapinv}"'
   mathml:
   - "&#x27dc;"
   latex:
@@ -9609,7 +9637,7 @@
   - "&#x27dc;"
 - unicodemath:
   - nabla
-  - __{grad}
+  - '"P{grad}"'
   asciimath:
   - nabla
   - grad
@@ -9617,7 +9645,7 @@
   - "&#x2207;"
   latex:
   - nabla
-  - __{grad}
+  - "\\text{P[grad]}"
   omml:
   - "&#x2207;"
   html:
@@ -9625,7 +9653,7 @@
 - unicodemath:
   - napprox
   asciimath:
-  - __{napprox}
+  - '"P{napprox}"'
   mathml:
   - "&#x2249;"
   latex:
@@ -9636,10 +9664,10 @@
   - "&#x2249;"
 - unicodemath:
   - nasymp
-  - __{notasymp}
+  - '"P{notasymp}"'
   asciimath:
-  - __{nasymp}
-  - __{notasymp}
+  - '"P{nasymp}"'
+  - '"P{notasymp}"'
   mathml:
   - "&#x226d;"
   latex:
@@ -9650,9 +9678,9 @@
   html:
   - "&#x226d;"
 - unicodemath:
-  - __{natural}
+  - '"P{natural}"'
   asciimath:
-  - __{natural}
+  - '"P{natural}"'
   mathml:
   - "&#x266e;"
   latex:
@@ -9664,7 +9692,7 @@
 - unicodemath:
   - ncong
   asciimath:
-  - __{ncong}
+  - '"P{ncong}"'
   mathml:
   - "&#x2247;"
   latex:
@@ -9676,25 +9704,25 @@
 - unicodemath:
   - neq
   - ne
-  - __{!=}
+  - '"P{!=}"'
   asciimath:
   - "!="
   - ne
-  - __{neq}
+  - '"P{neq}"'
   mathml:
   - "&#x2260;"
   latex:
   - neq
   - ne
-  - __{!=}
+  - "\\text{P[!=]}"
   omml:
   - "&#x2260;"
   html:
   - "&#x2260;"
 - unicodemath:
-  - __{Nearrow}
+  - '"P{Nearrow}"'
   asciimath:
-  - __{Nearrow}
+  - '"P{Nearrow}"'
   mathml:
   - "&#x21d7;"
   latex:
@@ -9705,26 +9733,26 @@
   - "&#x21d7;"
 - unicodemath:
   - neg
-  - __{not}
-  - __{lnot}
+  - '"P{not}"'
+  - '"P{lnot}"'
   asciimath:
   - neg
   - not
-  - __{lnot}
+  - '"P{lnot}"'
   mathml:
   - "&#xac;"
   latex:
   - lnot
   - neg
-  - __{not}
+  - "\\text{P[not]}"
   omml:
   - "&#xac;"
   html:
   - "&#xac;"
 - unicodemath:
-  - __{neovnwarrow}
+  - '"P{neovnwarrow}"'
   asciimath:
-  - __{neovnwarrow}
+  - '"P{neovnwarrow}"'
   mathml:
   - "&#x2931;"
   latex:
@@ -9734,9 +9762,9 @@
   html:
   - "&#x2931;"
 - unicodemath:
-  - __{neovsearrow}
+  - '"P{neovsearrow}"'
   asciimath:
-  - __{neovsearrow}
+  - '"P{neovsearrow}"'
   mathml:
   - "&#x292e;"
   latex:
@@ -9746,11 +9774,11 @@
   html:
   - "&#x292e;"
 - unicodemath:
-  - __{neptune}
-  - __{Neptune}
+  - '"P{neptune}"'
+  - '"P{Neptune}"'
   asciimath:
-  - __{neptune}
-  - __{Neptune}
+  - '"P{neptune}"'
+  - '"P{Neptune}"'
   mathml:
   - "&#x2646;"
   latex:
@@ -9763,17 +9791,17 @@
 - unicodemath:
   - neq
   - ne
-  - __{!=}
+  - '"P{!=}"'
   asciimath:
   - "!="
   - ne
-  - __{neq}
+  - '"P{neq}"'
   mathml:
   - "&#x2260;"
   latex:
   - neq
   - ne
-  - __{!=}
+  - "\\text{P[!=]}"
   omml:
   - "&#x2260;"
   html:
@@ -9781,7 +9809,7 @@
 - unicodemath:
   - nequiv
   asciimath:
-  - __{nequiv}
+  - '"P{nequiv}"'
   mathml:
   - "&#x2262;"
   latex:
@@ -9791,9 +9819,9 @@
   html:
   - "&#x2262;"
 - unicodemath:
-  - __{neswarrow}
+  - '"P{neswarrow}"'
   asciimath:
-  - __{neswarrow}
+  - '"P{neswarrow}"'
   mathml:
   - "&#x2922;"
   latex:
@@ -9803,9 +9831,9 @@
   html:
   - "&#x2922;"
 - unicodemath:
-  - __{neuter}
+  - '"P{neuter}"'
   asciimath:
-  - __{neuter}
+  - '"P{neuter}"'
   mathml:
   - "&#x26b2;"
   latex:
@@ -9816,10 +9844,10 @@
   - "&#x26b2;"
 - unicodemath:
   - nexists
-  - __{nexi}
+  - '"P{nexi}"'
   asciimath:
-  - __{nexists}
-  - __{nexi}
+  - '"P{nexists}"'
+  - '"P{nexi}"'
   mathml:
   - "&#x2204;"
   latex:
@@ -9831,10 +9859,10 @@
   - "&#x2204;"
 - unicodemath:
   - ngeq
-  - __{ngeqslant}
+  - '"P{ngeqslant}"'
   asciimath:
-  - __{ngeq}
-  - __{ngeqslant}
+  - '"P{ngeq}"'
+  - '"P{ngeqslant}"'
   mathml:
   - "&#x2271;"
   latex:
@@ -9846,25 +9874,25 @@
   - "&#x2271;"
 - unicodemath:
   - ngt
-  - __{ngtr}
+  - '"P{ngtr}"'
   asciimath:
-  - __{ngt}
-  - __{ngtr}
+  - '"P{ngt}"'
+  - '"P{ngtr}"'
   mathml:
   - "&#x226f;"
   latex:
   - ngtr
-  - __{ngt}
+  - "\\text{P[ngt]}"
   omml:
   - "&#x226f;"
   html:
   - "&#x226f;"
 - unicodemath:
-  - __{NotGreaterLess}
-  - __{ngtrless}
+  - '"P{NotGreaterLess}"'
+  - '"P{ngtrless}"'
   asciimath:
-  - __{NotGreaterLess}
-  - __{ngtrless}
+  - '"P{NotGreaterLess}"'
+  - '"P{ngtrless}"'
   mathml:
   - "&#x2279;"
   latex:
@@ -9875,11 +9903,11 @@
   html:
   - "&#x2279;"
 - unicodemath:
-  - __{NotGreaterTilde}
-  - __{ngtrsim}
+  - '"P{NotGreaterTilde}"'
+  - '"P{ngtrsim}"'
   asciimath:
-  - __{NotGreaterTilde}
-  - __{ngtrsim}
+  - '"P{NotGreaterTilde}"'
+  - '"P{ngtrsim}"'
   mathml:
   - "&#x2275;"
   latex:
@@ -9890,9 +9918,9 @@
   html:
   - "&#x2275;"
 - unicodemath:
-  - __{nHdownarrow}
+  - '"P{nHdownarrow}"'
   asciimath:
-  - __{nHdownarrow}
+  - '"P{nHdownarrow}"'
   mathml:
   - "&#x21df;"
   latex:
@@ -9902,9 +9930,9 @@
   html:
   - "&#x21df;"
 - unicodemath:
-  - __{nhpar}
+  - '"P{nhpar}"'
   asciimath:
-  - __{nhpar}
+  - '"P{nhpar}"'
   mathml:
   - "&#x2af2;"
   latex:
@@ -9914,9 +9942,9 @@
   html:
   - "&#x2af2;"
 - unicodemath:
-  - __{nHuparrow}
+  - '"P{nHuparrow}"'
   asciimath:
-  - __{nHuparrow}
+  - '"P{nHuparrow}"'
   mathml:
   - "&#x21de;"
   latex:
@@ -9926,9 +9954,9 @@
   html:
   - "&#x21de;"
 - unicodemath:
-  - __{nhVvert}
+  - '"P{nhVvert}"'
   asciimath:
-  - __{nhVvert}
+  - '"P{nhVvert}"'
   mathml:
   - "&#x2af5;"
   latex:
@@ -9939,10 +9967,10 @@
   - "&#x2af5;"
 - unicodemath:
   - ni
-  - __{owns}
+  - '"P{owns}"'
   asciimath:
-  - __{ni}
-  - __{owns}
+  - '"P{ni}"'
+  - '"P{owns}"'
   mathml:
   - "&#x220b;"
   latex:
@@ -9954,26 +9982,26 @@
   - "&#x220b;"
 - unicodemath:
   - notin
-  - __{!in}
-  - __{nin}
+  - '"P{!in}"'
+  - '"P{nin}"'
   asciimath:
   - notin
   - "!in"
-  - __{nin}
+  - '"P{nin}"'
   mathml:
   - "&#x2209;"
   latex:
   - notin
   - nin
-  - __{!in}
+  - "\\text{P[!in]}"
   omml:
   - "&#x2209;"
   html:
   - "&#x2209;"
 - unicodemath:
-  - __{niobar}
+  - '"P{niobar}"'
   asciimath:
-  - __{niobar}
+  - '"P{niobar}"'
   mathml:
   - "&#x22fe;"
   latex:
@@ -9983,9 +10011,9 @@
   html:
   - "&#x22fe;"
 - unicodemath:
-  - __{nis}
+  - '"P{nis}"'
   asciimath:
-  - __{nis}
+  - '"P{nis}"'
   mathml:
   - "&#x22fc;"
   latex:
@@ -9995,9 +10023,9 @@
   html:
   - "&#x22fc;"
 - unicodemath:
-  - __{nisd}
+  - '"P{nisd}"'
   asciimath:
-  - __{nisd}
+  - '"P{nisd}"'
   mathml:
   - "&#x22fa;"
   latex:
@@ -10009,7 +10037,7 @@
 - unicodemath:
   - nLeftarrow
   asciimath:
-  - __{nLeftarrow}
+  - '"P{nLeftarrow}"'
   mathml:
   - "&#x21cd;"
   latex:
@@ -10021,7 +10049,7 @@
 - unicodemath:
   - nLeftrightarrow
   asciimath:
-  - __{nLeftrightarrow}
+  - '"P{nLeftrightarrow}"'
   mathml:
   - "&#x21ce;"
   latex:
@@ -10032,10 +10060,10 @@
   - "&#x21ce;"
 - unicodemath:
   - nleq
-  - __{nleqslant}
+  - '"P{nleqslant}"'
   asciimath:
-  - __{nleq}
-  - __{nleqslant}
+  - '"P{nleq}"'
+  - '"P{nleqslant}"'
   mathml:
   - "&#x2270;"
   latex:
@@ -10048,7 +10076,7 @@
 - unicodemath:
   - nless
   asciimath:
-  - __{nless}
+  - '"P{nless}"'
   mathml:
   - "&#x226e;"
   latex:
@@ -10058,9 +10086,9 @@
   html:
   - "&#x226e;"
 - unicodemath:
-  - __{nlessgtr}
+  - '"P{nlessgtr}"'
   asciimath:
-  - __{nlessgtr}
+  - '"P{nlessgtr}"'
   mathml:
   - "&#x2278;"
   latex:
@@ -10070,11 +10098,11 @@
   html:
   - "&#x2278;"
 - unicodemath:
-  - __{NotLessTilde}
-  - __{nlesssim}
+  - '"P{NotLessTilde}"'
+  - '"P{nlesssim}"'
   asciimath:
-  - __{NotLessTilde}
-  - __{nlesssim}
+  - '"P{NotLessTilde}"'
+  - '"P{nlesssim}"'
   mathml:
   - "&#x2274;"
   latex:
@@ -10087,7 +10115,7 @@
 - unicodemath:
   - nmid
   asciimath:
-  - __{nmid}
+  - '"P{nmid}"'
   mathml:
   - "&#x2224;"
   latex:
@@ -10097,9 +10125,9 @@
   html:
   - "&#x2224;"
 - unicodemath:
-  - __{NN}
+  - '"P{NN}"'
   asciimath:
-  - __{NN}
+  - '"P{NN}"'
   mathml:
   - "&#x2115;"
   latex:
@@ -10110,10 +10138,10 @@
   - "&#x2115;"
 - unicodemath:
   - notni
-  - __{nni}
+  - '"P{nni}"'
   asciimath:
-  - __{notni}
-  - __{nni}
+  - '"P{notni}"'
+  - '"P{nni}"'
   mathml:
   - "&#x220c;"
   latex:
@@ -10124,48 +10152,47 @@
   html:
   - "&#x220c;"
 - unicodemath:
-  - bigcap
-  - __{bigcap}
-  - __{nnn}
-  - __{dint}
+  - '"P{bigcap}"'
+  - '"P{nnn}"'
+  - '"P{dint}"'
   asciimath:
   - bigcap
   - nnn
-  - __{dint}
+  - '"P{dint}"'
   mathml:
   - "&#x22c2;"
   latex:
   - bigcap
   - dint
-  - __{nnn}
+  - "\\text{P[nnn]}"
   omml:
   - "&#x22c2;"
   html:
   - "&#x22c2;"
 - unicodemath:
   - neg
-  - __{not}
-  - __{lnot}
+  - '"P{not}"'
+  - '"P{lnot}"'
   asciimath:
   - neg
   - not
-  - __{lnot}
+  - '"P{lnot}"'
   mathml:
   - "&#xac;"
   latex:
   - lnot
   - neg
-  - __{not}
+  - "\\text{P[not]}"
   omml:
   - "&#xac;"
   html:
   - "&#xac;"
 - unicodemath:
-  - __{APLnotbackslash}
-  - __{notbackslash}
+  - '"P{APLnotbackslash}"'
+  - '"P{notbackslash}"'
   asciimath:
-  - __{APLnotbackslash}
-  - __{notbackslash}
+  - '"P{APLnotbackslash}"'
+  - '"P{notbackslash}"'
   mathml:
   - "&#x2340;"
   latex:
@@ -10177,28 +10204,28 @@
   - "&#x2340;"
 - unicodemath:
   - notin
-  - __{!in}
-  - __{nin}
+  - '"P{!in}"'
+  - '"P{nin}"'
   asciimath:
   - notin
   - "!in"
-  - __{nin}
+  - '"P{nin}"'
   mathml:
   - "&#x2209;"
   latex:
   - notin
   - nin
-  - __{!in}
+  - "\\text{P[!in]}"
   omml:
   - "&#x2209;"
   html:
   - "&#x2209;"
 - unicodemath:
-  - __{APLnotslash}
-  - __{notslash}
+  - '"P{APLnotslash}"'
+  - '"P{notslash}"'
   asciimath:
-  - __{APLnotslash}
-  - __{notslash}
+  - '"P{APLnotslash}"'
+  - '"P{notslash}"'
   mathml:
   - "&#x233f;"
   latex:
@@ -10211,7 +10238,7 @@
 - unicodemath:
   - nparallel
   asciimath:
-  - __{nparallel}
+  - '"P{nparallel}"'
   mathml:
   - "&#x2226;"
   latex:
@@ -10221,9 +10248,9 @@
   html:
   - "&#x2226;"
 - unicodemath:
-  - __{npolint}
+  - '"P{npolint}"'
   asciimath:
-  - __{npolint}
+  - '"P{npolint}"'
   mathml:
   - "&#x2a14;"
   latex:
@@ -10235,7 +10262,7 @@
 - unicodemath:
   - nprec
   asciimath:
-  - __{nprec}
+  - '"P{nprec}"'
   mathml:
   - "&#x2280;"
   latex:
@@ -10246,10 +10273,10 @@
   - "&#x2280;"
 - unicodemath:
   - npreccurlyeq
-  - __{npreceq}
+  - '"P{npreceq}"'
   asciimath:
-  - __{npreccurlyeq}
-  - __{npreceq}
+  - '"P{npreccurlyeq}"'
+  - '"P{npreceq}"'
   mathml:
   - "&#x22e0;"
   latex:
@@ -10262,7 +10289,7 @@
 - unicodemath:
   - nRightarrow
   asciimath:
-  - __{nRightarrow}
+  - '"P{nRightarrow}"'
   mathml:
   - "&#x21cf;"
   latex:
@@ -10274,7 +10301,7 @@
 - unicodemath:
   - nsim
   asciimath:
-  - __{nsim}
+  - '"P{nsim}"'
   mathml:
   - "&#x2241;"
   latex:
@@ -10285,10 +10312,10 @@
   - "&#x2241;"
 - unicodemath:
   - nsimeq
-  - __{nsime}
+  - '"P{nsime}"'
   asciimath:
-  - __{nsimeq}
-  - __{nsime}
+  - '"P{nsimeq}"'
+  - '"P{nsime}"'
   mathml:
   - "&#x2244;"
   latex:
@@ -10301,7 +10328,7 @@
 - unicodemath:
   - nsqsubseteq
   asciimath:
-  - __{nsqsubseteq}
+  - '"P{nsqsubseteq}"'
   mathml:
   - "&#x22e2;"
   latex:
@@ -10312,30 +10339,30 @@
   - "&#x22e2;"
 - unicodemath:
   - nsqsuperseteq
-  - __{nsqsupseteq}
+  - '"P{nsqsupseteq}"'
   asciimath:
-  - __{nsqsuperseteq}
-  - __{nsqsupseteq}
+  - '"P{nsqsuperseteq}"'
+  - '"P{nsqsupseteq}"'
   mathml:
   - "&#x22e3;"
   latex:
   - nsqsupseteq
-  - __{nsqsuperseteq}
+  - "\\text{P[nsqsuperseteq]}"
   omml:
   - "&#x22e3;"
   html:
   - "&#x22e3;"
 - unicodemath:
   - nsub
-  - __{nsubset}
+  - '"P{nsubset}"'
   asciimath:
-  - __{nsub}
-  - __{nsubset}
+  - '"P{nsub}"'
+  - '"P{nsubset}"'
   mathml:
   - "&#x2284;"
   latex:
   - nsubset
-  - __{nsub}
+  - "\\text{P[nsub]}"
   omml:
   - "&#x2284;"
   html:
@@ -10343,7 +10370,7 @@
 - unicodemath:
   - nsucc
   asciimath:
-  - __{nsucc}
+  - '"P{nsucc}"'
   mathml:
   - "&#x2281;"
   latex:
@@ -10354,10 +10381,10 @@
   - "&#x2281;"
 - unicodemath:
   - nsucccurlyeq
-  - __{nsucceq}
+  - '"P{nsucceq}"'
   asciimath:
-  - __{nsucccurlyeq}
-  - __{nsucceq}
+  - '"P{nsucccurlyeq}"'
+  - '"P{nsucceq}"'
   mathml:
   - "&#x22e1;"
   latex:
@@ -10369,25 +10396,25 @@
   - "&#x22e1;"
 - unicodemath:
   - nsup
-  - __{nsupset}
+  - '"P{nsupset}"'
   asciimath:
-  - __{nsup}
-  - __{nsupset}
+  - '"P{nsup}"'
+  - '"P{nsupset}"'
   mathml:
   - "&#x2285;"
   latex:
   - nsupset
-  - __{nsup}
+  - "\\text{P[nsup]}"
   omml:
   - "&#x2285;"
   html:
   - "&#x2285;"
 - unicodemath:
   - ntriangleleft
-  - __{NotLeftTriangle}
+  - '"P{NotLeftTriangle}"'
   asciimath:
-  - __{ntriangleleft}
-  - __{NotLeftTriangle}
+  - '"P{ntriangleleft}"'
+  - '"P{NotLeftTriangle}"'
   mathml:
   - "&#x22ea;"
   latex:
@@ -10399,10 +10426,10 @@
   - "&#x22ea;"
 - unicodemath:
   - ntriangleright
-  - __{NotRightTriangle}
+  - '"P{NotRightTriangle}"'
   asciimath:
-  - __{ntriangleright}
-  - __{NotRightTriangle}
+  - '"P{ntriangleright}"'
+  - '"P{NotRightTriangle}"'
   mathml:
   - "&#x22eb;"
   latex:
@@ -10414,10 +10441,10 @@
   - "&#x22eb;"
 - unicodemath:
   - nu
-  - __{upnu}
+  - '"P{upnu}"'
   asciimath:
   - nu
-  - __{upnu}
+  - '"P{upnu}"'
   mathml:
   - "&#x3bd;"
   latex:
@@ -10428,11 +10455,11 @@
   html:
   - "&#x3bd;"
 - unicodemath:
-  - __{ntrianglelefteq}
-  - __{nunlhd}
+  - '"P{ntrianglelefteq}"'
+  - '"P{nunlhd}"'
   asciimath:
-  - __{ntrianglelefteq}
-  - __{nunlhd}
+  - '"P{ntrianglelefteq}"'
+  - '"P{nunlhd}"'
   mathml:
   - "&#x22ec;"
   latex:
@@ -10444,10 +10471,10 @@
   - "&#x22ec;"
 - unicodemath:
   - ntrianglerighteq
-  - __{nunrhd}
+  - '"P{nunrhd}"'
   asciimath:
-  - __{ntrianglerighteq}
-  - __{nunrhd}
+  - '"P{ntrianglerighteq}"'
+  - '"P{nunrhd}"'
   mathml:
   - "&#x22ed;"
   latex:
@@ -10458,9 +10485,9 @@
   html:
   - "&#x22ed;"
 - unicodemath:
-  - __{nVDash}
+  - '"P{nVDash}"'
   asciimath:
-  - __{nVDash}
+  - '"P{nVDash}"'
   mathml:
   - "&#x22af;"
   latex:
@@ -10470,9 +10497,9 @@
   html:
   - "&#x22af;"
 - unicodemath:
-  - __{nvinfty}
+  - '"P{nvinfty}"'
   asciimath:
-  - __{nvinfty}
+  - '"P{nvinfty}"'
   mathml:
   - "&#x29de;"
   latex:
@@ -10482,9 +10509,9 @@
   html:
   - "&#x29de;"
 - unicodemath:
-  - __{nvLeftarrow}
+  - '"P{nvLeftarrow}"'
   asciimath:
-  - __{nvLeftarrow}
+  - '"P{nvLeftarrow}"'
   mathml:
   - "&#x2902;"
   latex:
@@ -10494,9 +10521,9 @@
   html:
   - "&#x2902;"
 - unicodemath:
-  - __{nVleftarrowtail}
+  - '"P{nVleftarrowtail}"'
   asciimath:
-  - __{nVleftarrowtail}
+  - '"P{nVleftarrowtail}"'
   mathml:
   - "&#x2b3a;"
   latex:
@@ -10506,9 +10533,9 @@
   html:
   - "&#x2b3a;"
 - unicodemath:
-  - __{nvLeftrightarrow}
+  - '"P{nvLeftrightarrow}"'
   asciimath:
-  - __{nvLeftrightarrow}
+  - '"P{nvLeftrightarrow}"'
   mathml:
   - "&#x2904;"
   latex:
@@ -10518,9 +10545,9 @@
   html:
   - "&#x2904;"
 - unicodemath:
-  - __{nvRightarrow}
+  - '"P{nvRightarrow}"'
   asciimath:
-  - __{nvRightarrow}
+  - '"P{nvRightarrow}"'
   mathml:
   - "&#x2903;"
   latex:
@@ -10530,9 +10557,9 @@
   html:
   - "&#x2903;"
 - unicodemath:
-  - __{nVtwoheadleftarrow}
+  - '"P{nVtwoheadleftarrow}"'
   asciimath:
-  - __{nVtwoheadleftarrow}
+  - '"P{nVtwoheadleftarrow}"'
   mathml:
   - "&#x2b35;"
   latex:
@@ -10542,9 +10569,9 @@
   html:
   - "&#x2b35;"
 - unicodemath:
-  - __{nVtwoheadleftarrowtail}
+  - '"P{nVtwoheadleftarrowtail}"'
   asciimath:
-  - __{nVtwoheadleftarrowtail}
+  - '"P{nVtwoheadleftarrowtail}"'
   mathml:
   - "&#x2b3d;"
   latex:
@@ -10554,9 +10581,9 @@
   html:
   - "&#x2b3d;"
 - unicodemath:
-  - __{nVtwoheadrightarrow}
+  - '"P{nVtwoheadrightarrow}"'
   asciimath:
-  - __{nVtwoheadrightarrow}
+  - '"P{nVtwoheadrightarrow}"'
   mathml:
   - "&#x2901;"
   latex:
@@ -10566,9 +10593,9 @@
   html:
   - "&#x2901;"
 - unicodemath:
-  - __{nVtwoheadrightarrowtail}
+  - '"P{nVtwoheadrightarrowtail}"'
   asciimath:
-  - __{nVtwoheadrightarrowtail}
+  - '"P{nVtwoheadrightarrowtail}"'
   mathml:
   - "&#x2918;"
   latex:
@@ -10578,9 +10605,9 @@
   html:
   - "&#x2918;"
 - unicodemath:
-  - __{Nwarrow}
+  - '"P{Nwarrow}"'
   asciimath:
-  - __{Nwarrow}
+  - '"P{Nwarrow}"'
   mathml:
   - "&#x21d6;"
   latex:
@@ -10590,9 +10617,9 @@
   html:
   - "&#x21d6;"
 - unicodemath:
-  - __{nwovnearrow}
+  - '"P{nwovnearrow}"'
   asciimath:
-  - __{nwovnearrow}
+  - '"P{nwovnearrow}"'
   mathml:
   - "&#x2932;"
   latex:
@@ -10602,9 +10629,9 @@
   html:
   - "&#x2932;"
 - unicodemath:
-  - __{nwsearrow}
+  - '"P{nwsearrow}"'
   asciimath:
-  - __{nwsearrow}
+  - '"P{nwsearrow}"'
   mathml:
   - "&#x2921;"
   latex:
@@ -10615,23 +10642,23 @@
   - "&#x2921;"
 - unicodemath:
   - oast
-  - __{circledast}
+  - '"P{circledast}"'
   asciimath:
-  - __{oast}
-  - __{circledast}
+  - '"P{oast}"'
+  - '"P{circledast}"'
   mathml:
   - "&#x229b;"
   latex:
   - circledast
-  - __{oast}
+  - "\\text{P[oast]}"
   omml:
   - "&#x229b;"
   html:
   - "&#x229b;"
 - unicodemath:
-  - __{obar}
+  - '"P{obar}"'
   asciimath:
-  - __{obar}
+  - '"P{obar}"'
   mathml:
   - "&#x233d;"
   latex:
@@ -10641,9 +10668,9 @@
   html:
   - "&#x233d;"
 - unicodemath:
-  - __{obot}
+  - '"P{obot}"'
   asciimath:
-  - __{obot}
+  - '"P{obot}"'
   mathml:
   - "&#x29ba;"
   latex:
@@ -10665,9 +10692,9 @@
   html:
   - "&#x23de;"
 - unicodemath:
-  - __{obrbrak}
+  - '"P{obrbrak}"'
   asciimath:
-  - __{obrbrak}
+  - '"P{obrbrak}"'
   mathml:
   - "&#x23e0;"
   latex:
@@ -10677,11 +10704,11 @@
   html:
   - "&#x23e0;"
 - unicodemath:
-  - __{circledbslash}
-  - __{obslash}
+  - '"P{circledbslash}"'
+  - '"P{obslash}"'
   asciimath:
-  - __{circledbslash}
-  - __{obslash}
+  - '"P{circledbslash}"'
+  - '"P{obslash}"'
   mathml:
   - "&#x29b8;"
   latex:
@@ -10693,23 +10720,23 @@
   - "&#x29b8;"
 - unicodemath:
   - ocirc
-  - __{circledcirc}
+  - '"P{circledcirc}"'
   asciimath:
-  - __{ocirc}
-  - __{circledcirc}
+  - '"P{ocirc}"'
+  - '"P{circledcirc}"'
   mathml:
   - "&#x229a;"
   latex:
   - circledcirc
-  - __{ocirc}
+  - "\\text{P[ocirc]}"
   omml:
   - "&#x229a;"
   html:
   - "&#x229a;"
 - unicodemath:
-  - __{ocommatopright}
+  - '"P{ocommatopright}"'
   asciimath:
-  - __{ocommatopright}
+  - '"P{ocommatopright}"'
   mathml:
   - "&#x315;"
   latex:
@@ -10720,41 +10747,41 @@
   - "&#x315;"
 - unicodemath:
   - eqno
-  - __{#}
-  - __{octothorpe}
+  - '"P{#}"'
+  - '"P{octothorpe}"'
   asciimath:
   - "#"
-  - __{eqno}
-  - __{octothorpe}
+  - '"P{eqno}"'
+  - '"P{octothorpe}"'
   mathml:
   - "&#x23;"
   latex:
   - octothorpe
   - "#"
-  - __{eqno}
+  - "\\text{P[eqno]}"
   omml:
   - "&#x23;"
   html:
   - "&#x23;"
 - unicodemath:
   - odash
-  - __{circleddash}
+  - '"P{circleddash}"'
   asciimath:
-  - __{odash}
-  - __{circleddash}
+  - '"P{odash}"'
+  - '"P{circleddash}"'
   mathml:
   - "&#x229d;"
   latex:
   - circleddash
-  - __{odash}
+  - "\\text{P[odash]}"
   omml:
   - "&#x229d;"
   html:
   - "&#x229d;"
 - unicodemath:
-  - __{odiv}
+  - '"P{odiv}"'
   asciimath:
-  - __{odiv}
+  - '"P{odiv}"'
   mathml:
   - "&#x2a38;"
   latex:
@@ -10765,7 +10792,7 @@
   - "&#x2a38;"
 - unicodemath:
   - odot
-  - __{o.}
+  - '"P{o.}"'
   asciimath:
   - odot
   - o.
@@ -10773,15 +10800,15 @@
   - "&#x2299;"
   latex:
   - odot
-  - __{o.}
+  - "\\text{P[o.]}"
   omml:
   - "&#x2299;"
   html:
   - "&#x2299;"
 - unicodemath:
-  - __{odotslashdot}
+  - '"P{odotslashdot}"'
   asciimath:
-  - __{odotslashdot}
+  - '"P{odotslashdot}"'
   mathml:
   - "&#x29bc;"
   latex:
@@ -10792,23 +10819,23 @@
   - "&#x29bc;"
 - unicodemath:
   - oeq
-  - __{circledequal}
+  - '"P{circledequal}"'
   asciimath:
-  - __{oeq}
-  - __{circledequal}
+  - '"P{oeq}"'
+  - '"P{circledequal}"'
   mathml:
   - "&#x229c;"
   latex:
   - circledequal
-  - __{oeq}
+  - "\\text{P[oeq]}"
   omml:
   - "&#x229c;"
   html:
   - "&#x229c;"
 - unicodemath:
-  - __{oiiint}
+  - '"P{oiiint}"'
   asciimath:
-  - __{oiiint}
+  - '"P{oiiint}"'
   mathml:
   - "&#x2230;"
   latex:
@@ -10818,11 +10845,11 @@
   html:
   - "&#x2230;"
 - unicodemath:
-  - __{dbloint}
-  - __{oiint}
+  - '"P{dbloint}"'
+  - '"P{oiint}"'
   asciimath:
-  - __{dbloint}
-  - __{oiint}
+  - '"P{dbloint}"'
+  - '"P{oiint}"'
   mathml:
   - "&#x222f;"
   latex:
@@ -10845,9 +10872,9 @@
   html:
   - "&#x222e;"
 - unicodemath:
-  - __{olcross}
+  - '"P{olcross}"'
   asciimath:
-  - __{olcross}
+  - '"P{olcross}"'
   mathml:
   - "&#x29bb;"
   latex:
@@ -10857,11 +10884,11 @@
   html:
   - "&#x29bb;"
 - unicodemath:
-  - __{circledless}
-  - __{olessthan}
+  - '"P{circledless}"'
+  - '"P{olessthan}"'
   asciimath:
-  - __{circledless}
-  - __{olessthan}
+  - '"P{circledless}"'
+  - '"P{olessthan}"'
   mathml:
   - "&#x29c0;"
   latex:
@@ -10873,10 +10900,10 @@
   - "&#x29c0;"
 - unicodemath:
   - omega
-  - __{upomega}
+  - '"P{upomega}"'
   asciimath:
   - omega
-  - __{upomega}
+  - '"P{upomega}"'
   mathml:
   - "&#x3c9;"
   latex:
@@ -10889,7 +10916,7 @@
 - unicodemath:
   - ominus
   asciimath:
-  - __{ominus}
+  - '"P{ominus}"'
   mathml:
   - "&#x2296;"
   latex:
@@ -10908,15 +10935,15 @@
   - "&#x221e;"
   latex:
   - infty
-  - __{oo}
+  - "\\text{P[oo]}"
   omml:
   - "&#x221e;"
   html:
   - "&#x221e;"
 - unicodemath:
-  - __{operp}
+  - '"P{operp}"'
   asciimath:
-  - __{operp}
+  - '"P{operp}"'
   mathml:
   - "&#x29b9;"
   latex:
@@ -10927,7 +10954,7 @@
   - "&#x29b9;"
 - unicodemath:
   - oplus
-  - __{o+}
+  - '"P{o+}"'
   asciimath:
   - oplus
   - o+
@@ -10935,15 +10962,15 @@
   - "&#x2295;"
   latex:
   - oplus
-  - __{o+}
+  - "\\text{P[o+]}"
   omml:
   - "&#x2295;"
   html:
   - "&#x2295;"
 - unicodemath:
-  - __{opluslhrim}
+  - '"P{opluslhrim}"'
   asciimath:
-  - __{opluslhrim}
+  - '"P{opluslhrim}"'
   mathml:
   - "&#x2a2d;"
   latex:
@@ -10953,9 +10980,9 @@
   html:
   - "&#x2a2d;"
 - unicodemath:
-  - __{oplusrhrim}
+  - '"P{oplusrhrim}"'
   asciimath:
-  - __{oplusrhrim}
+  - '"P{oplusrhrim}"'
   mathml:
   - "&#x2a2e;"
   latex:
@@ -10965,11 +10992,11 @@
   html:
   - "&#x2a2e;"
 - unicodemath:
-  - __{multimapdotbothA}
-  - __{origof}
+  - '"P{multimapdotbothA}"'
+  - '"P{origof}"'
   asciimath:
-  - __{multimapdotbothA}
-  - __{origof}
+  - '"P{multimapdotbothA}"'
+  - '"P{origof}"'
   mathml:
   - "&#x22b6;"
   latex:
@@ -10980,9 +11007,9 @@
   html:
   - "&#x22b6;"
 - unicodemath:
-  - __{oslash}
+  - '"P{oslash}"'
   asciimath:
-  - __{oslash}
+  - '"P{oslash}"'
   mathml:
   - "&#x2298;"
   latex:
@@ -10992,9 +11019,9 @@
   html:
   - "&#x2298;"
 - unicodemath:
-  - __{Otimes}
+  - '"P{Otimes}"'
   asciimath:
-  - __{Otimes}
+  - '"P{Otimes}"'
   mathml:
   - "&#x2a37;"
   latex:
@@ -11004,9 +11031,9 @@
   html:
   - "&#x2a37;"
 - unicodemath:
-  - __{otimeshat}
+  - '"P{otimeshat}"'
   asciimath:
-  - __{otimeshat}
+  - '"P{otimeshat}"'
   mathml:
   - "&#x2a36;"
   latex:
@@ -11016,9 +11043,9 @@
   html:
   - "&#x2a36;"
 - unicodemath:
-  - __{otimeslhrim}
+  - '"P{otimeslhrim}"'
   asciimath:
-  - __{otimeslhrim}
+  - '"P{otimeslhrim}"'
   mathml:
   - "&#x2a34;"
   latex:
@@ -11028,9 +11055,9 @@
   html:
   - "&#x2a34;"
 - unicodemath:
-  - __{otimesrhrim}
+  - '"P{otimesrhrim}"'
   asciimath:
-  - __{otimesrhrim}
+  - '"P{otimesrhrim}"'
   mathml:
   - "&#x2a35;"
   latex:
@@ -11040,9 +11067,9 @@
   html:
   - "&#x2a35;"
 - unicodemath:
-  - __{oturnedcomma}
+  - '"P{oturnedcomma}"'
   asciimath:
-  - __{oturnedcomma}
+  - '"P{oturnedcomma}"'
   mathml:
   - "&#x312;"
   latex:
@@ -11052,9 +11079,9 @@
   html:
   - "&#x312;"
 - unicodemath:
-  - __{overbar}
+  - '"P{overbar}"'
   asciimath:
-  - __{overbar}
+  - '"P{overbar}"'
   mathml:
   - "&#x305;"
   latex:
@@ -11064,9 +11091,9 @@
   html:
   - "&#x305;"
 - unicodemath:
-  - __{overbracket}
+  - '"P{overbracket}"'
   asciimath:
-  - __{overbracket}
+  - '"P{overbracket}"'
   mathml:
   - "&#x23b4;"
   latex:
@@ -11076,9 +11103,9 @@
   html:
   - "&#x23b4;"
 - unicodemath:
-  - __{overleftrightarrow}
+  - '"P{overleftrightarrow}"'
   asciimath:
-  - __{overleftrightarrow}
+  - '"P{overleftrightarrow}"'
   mathml:
   - "&#x20e1;"
   latex:
@@ -11100,9 +11127,9 @@
   html:
   - "&#x203e;"
 - unicodemath:
-  - __{ovhook}
+  - '"P{ovhook}"'
   asciimath:
-  - __{ovhook}
+  - '"P{ovhook}"'
   mathml:
   - "&#x309;"
   latex:
@@ -11113,7 +11140,7 @@
   - "&#x309;"
 - unicodemath:
   - otimes
-  - __{ox}
+  - '"P{ox}"'
   asciimath:
   - otimes
   - ox
@@ -11121,15 +11148,15 @@
   - "&#x2297;"
   latex:
   - otimes
-  - __{ox}
+  - "\\text{P[ox]}"
   omml:
   - "&#x2297;"
   html:
   - "&#x2297;"
 - unicodemath:
-  - __{parallelogram}
+  - '"P{parallelogram}"'
   asciimath:
-  - __{parallelogram}
+  - '"P{parallelogram}"'
   mathml:
   - "&#x25b1;"
   latex:
@@ -11139,9 +11166,9 @@
   html:
   - "&#x25b1;"
 - unicodemath:
-  - __{parallelogramblack}
+  - '"P{parallelogramblack}"'
   asciimath:
-  - __{parallelogramblack}
+  - '"P{parallelogramblack}"'
   mathml:
   - "&#x25b0;"
   latex:
@@ -11152,9 +11179,9 @@
   - "&#x25b0;"
 - {}
 - unicodemath:
-  - __{parsim}
+  - '"P{parsim}"'
   asciimath:
-  - __{parsim}
+  - '"P{parsim}"'
   mathml:
   - "&#x2af3;"
   latex:
@@ -11165,23 +11192,23 @@
   - "&#x2af3;"
 - unicodemath:
   - partial
-  - __{del}
-  - __{partialup}
+  - '"P{del}"'
+  - '"P{partialup}"'
   asciimath:
   - partial
   - del
-  - __{partialup}
+  - '"P{partialup}"'
   mathml: []
   latex:
   - partialup
   - partial
-  - __{del}
+  - "\\text{P[del]}"
   omml: []
   html: []
 - unicodemath:
-  - __{partialmeetcontraction}
+  - '"P{partialmeetcontraction}"'
   asciimath:
-  - __{partialmeetcontraction}
+  - '"P{partialmeetcontraction}"'
   mathml:
   - "&#x2aa3;"
   latex:
@@ -11191,9 +11218,9 @@
   html:
   - "&#x2aa3;"
 - unicodemath:
-  - __{pencil}
+  - '"P{pencil}"'
   asciimath:
-  - __{pencil}
+  - '"P{pencil}"'
   mathml:
   - "&#x270e;"
   latex:
@@ -11203,9 +11230,9 @@
   html:
   - "&#x270e;"
 - unicodemath:
-  - __{pentagon}
+  - '"P{pentagon}"'
   asciimath:
-  - __{pentagon}
+  - '"P{pentagon}"'
   mathml:
   - "&#x2b20;"
   latex:
@@ -11215,9 +11242,9 @@
   html:
   - "&#x2b20;"
 - unicodemath:
-  - __{pentagonblack}
+  - '"P{pentagonblack}"'
   asciimath:
-  - __{pentagonblack}
+  - '"P{pentagonblack}"'
   mathml:
   - "&#x2b1f;"
   latex:
@@ -11227,11 +11254,11 @@
   html:
   - "&#x2b1f;"
 - unicodemath:
-  - __{%}
-  - __{percent}
+  - '"P{%}"'
+  - '"P{percent}"'
   asciimath:
   - "%"
-  - __{percent}
+  - '"P{percent}"'
   mathml:
   - "&#x25;"
   latex:
@@ -11243,10 +11270,10 @@
   - "&#x25;"
 - unicodemath:
   - "."
-  - __{period}
+  - '"P{period}"'
   asciimath:
   - "."
-  - __{period}
+  - '"P{period}"'
   mathml:
   - "."
   latex:
@@ -11259,25 +11286,25 @@
 - unicodemath:
   - bot
   - perp
-  - __{_|_}
+  - '"P{_|_}"'
   asciimath:
   - _|_
   - bot
-  - __{perp}
+  - '"P{perp}"'
   mathml:
   - "&#x22a5;"
   latex:
   - bot
-  - __{perp}
-  - __{_|_}
+  - "\\text{P[perp]}"
+  - "\\text{P[_|_]}"
   omml:
   - "&#x22a5;"
   html:
   - "&#x22a5;"
 - unicodemath:
-  - __{perps}
+  - '"P{perps}"'
   asciimath:
-  - __{perps}
+  - '"P{perps}"'
   mathml:
   - "&#x2ae1;"
   latex:
@@ -11287,11 +11314,11 @@
   html:
   - "&#x2ae1;"
 - unicodemath:
-  - __{nvrightarrow}
-  - __{pfun}
+  - '"P{nvrightarrow}"'
+  - '"P{pfun}"'
   asciimath:
-  - __{nvrightarrow}
-  - __{pfun}
+  - '"P{nvrightarrow}"'
+  - '"P{pfun}"'
   mathml:
   - "&#x21f8;"
   latex:
@@ -11303,10 +11330,10 @@
   - "&#x21f8;"
 - unicodemath:
   - varphi
-  - __{upvarphi}
+  - '"P{upvarphi}"'
   asciimath:
   - varphi
-  - __{upvarphi}
+  - '"P{upvarphi}"'
   mathml:
   - "&#x3c6;"
   latex:
@@ -11318,25 +11345,22 @@
   - "&#x3c6;"
 - unicodemath:
   - pi
-  - __{uppi}
+  - '"P{uppi}"'
   asciimath:
   - pi
-  - __{uppi}
-  mathml:
-  - "&#x3c0;"
+  - '"P{uppi}"'
+  mathml: []
   latex:
   - pi
   - uppi
-  omml:
-  - "&#x3c0;"
-  html:
-  - "&#x3C0;"
+  omml: []
+  html: []
 - unicodemath:
-  - __{nvrightarrowtail}
-  - __{pinj}
+  - '"P{nvrightarrowtail}"'
+  - '"P{pinj}"'
   asciimath:
-  - __{nvrightarrowtail}
-  - __{pinj}
+  - '"P{nvrightarrowtail}"'
+  - '"P{pinj}"'
   mathml:
   - "&#x2914;"
   latex:
@@ -11347,9 +11371,9 @@
   html:
   - "&#x2914;"
 - unicodemath:
-  - __{pisces}
+  - '"P{pisces}"'
   asciimath:
-  - __{pisces}
+  - '"P{pisces}"'
   mathml:
   - "&#x2653;"
   latex:
@@ -11361,7 +11385,7 @@
 - unicodemath:
   - pitchfork
   asciimath:
-  - __{pitchfork}
+  - '"P{pitchfork}"'
   mathml:
   - "&#x22d4;"
   latex:
@@ -11371,9 +11395,9 @@
   html:
   - "&#x22d4;"
 - unicodemath:
-  - __{Planckconst}
+  - '"P{Planckconst}"'
   asciimath:
-  - __{Planckconst}
+  - '"P{Planckconst}"'
   mathml:
   - "&#x210e;"
   latex:
@@ -11384,10 +11408,10 @@
   - "&#x210e;"
 - unicodemath:
   - "+"
-  - __{plus}
+  - '"P{plus}"'
   asciimath:
   - "+"
-  - __{plus}
+  - '"P{plus}"'
   mathml:
   - "+"
   latex:
@@ -11398,9 +11422,9 @@
   html:
   - "+"
 - unicodemath:
-  - __{plusdot}
+  - '"P{plusdot}"'
   asciimath:
-  - __{plusdot}
+  - '"P{plusdot}"'
   mathml:
   - "&#x2a25;"
   latex:
@@ -11410,9 +11434,9 @@
   html:
   - "&#x2a25;"
 - unicodemath:
-  - __{pluseqq}
+  - '"P{pluseqq}"'
   asciimath:
-  - __{pluseqq}
+  - '"P{pluseqq}"'
   mathml:
   - "&#x2a72;"
   latex:
@@ -11422,9 +11446,9 @@
   html:
   - "&#x2a72;"
 - unicodemath:
-  - __{plushat}
+  - '"P{plushat}"'
   asciimath:
-  - __{plushat}
+  - '"P{plushat}"'
   mathml:
   - "&#x2a23;"
   latex:
@@ -11434,9 +11458,9 @@
   html:
   - "&#x2a23;"
 - unicodemath:
-  - __{plussim}
+  - '"P{plussim}"'
   asciimath:
-  - __{plussim}
+  - '"P{plussim}"'
   mathml:
   - "&#x2a26;"
   latex:
@@ -11446,9 +11470,9 @@
   html:
   - "&#x2a26;"
 - unicodemath:
-  - __{plussubtwo}
+  - '"P{plussubtwo}"'
   asciimath:
-  - __{plussubtwo}
+  - '"P{plussubtwo}"'
   mathml:
   - "&#x2a27;"
   latex:
@@ -11458,9 +11482,9 @@
   html:
   - "&#x2a27;"
 - unicodemath:
-  - __{plustrif}
+  - '"P{plustrif}"'
   asciimath:
-  - __{plustrif}
+  - '"P{plustrif}"'
   mathml:
   - "&#x2a28;"
   latex:
@@ -11470,11 +11494,11 @@
   html:
   - "&#x2a28;"
 - unicodemath:
-  - __{pluto}
-  - __{Pluto}
+  - '"P{pluto}"'
+  - '"P{Pluto}"'
   asciimath:
-  - __{pluto}
-  - __{Pluto}
+  - '"P{pluto}"'
+  - '"P{Pluto}"'
   mathml:
   - "&#x2647;"
   latex:
@@ -11486,7 +11510,7 @@
   - "&#x2647;"
 - unicodemath:
   - pm
-  - __{+-}
+  - '"P{+-}"'
   asciimath:
   - "+-"
   - pm
@@ -11494,15 +11518,15 @@
   - "&#xb1;"
   latex:
   - pm
-  - __{+-}
+  - "\\text{P[+-]}"
   omml:
   - "&#xb1;"
   html:
   - "&#xb1;"
 - unicodemath:
-  - __{pointint}
+  - '"P{pointint}"'
   asciimath:
-  - __{pointint}
+  - '"P{pointint}"'
   mathml:
   - "&#x2a15;"
   latex:
@@ -11512,9 +11536,9 @@
   html:
   - "&#x2a15;"
 - unicodemath:
-  - __{pointright}
+  - '"P{pointright}"'
   asciimath:
-  - __{pointright}
+  - '"P{pointright}"'
   mathml:
   - "&#x261e;"
   latex:
@@ -11524,9 +11548,9 @@
   html:
   - "&#x261e;"
 - unicodemath:
-  - __{postalmark}
+  - '"P{postalmark}"'
   asciimath:
-  - __{postalmark}
+  - '"P{postalmark}"'
   mathml:
   - "&#x3012;"
   latex:
@@ -11536,13 +11560,13 @@
   html:
   - "&#x3012;"
 - unicodemath:
-  - __{mathsterling}
-  - __{sterling}
-  - __{pounds}
+  - '"P{mathsterling}"'
+  - '"P{sterling}"'
+  - '"P{pounds}"'
   asciimath:
-  - __{mathsterling}
-  - __{sterling}
-  - __{pounds}
+  - '"P{mathsterling}"'
+  - '"P{sterling}"'
+  - '"P{pounds}"'
   mathml:
   - "&#xa3;"
   latex:
@@ -11555,57 +11579,57 @@
   - "&#xa3;"
 - unicodemath:
   - pppprime
-  - __{fourth}
-  - __{qprime}
+  - '"P{fourth}"'
+  - '"P{qprime}"'
   asciimath:
-  - __{pppprime}
-  - __{fourth}
-  - __{qprime}
+  - '"P{pppprime}"'
+  - '"P{fourth}"'
+  - '"P{qprime}"'
   mathml:
   - "&#x2057;"
   latex:
   - fourth
   - qprime
-  - __{pppprime}
+  - "\\text{P[pppprime]}"
   omml:
   - "&#x2057;"
   html:
   - "&#x2057;"
 - unicodemath:
   - ppprime
-  - __{trprime}
-  - __{third}
+  - '"P{trprime}"'
+  - '"P{third}"'
   asciimath:
-  - __{ppprime}
-  - __{trprime}
-  - __{third}
+  - '"P{ppprime}"'
+  - '"P{trprime}"'
+  - '"P{third}"'
   mathml:
   - "&#x2034;"
   latex:
   - trprime
   - third
-  - __{ppprime}
+  - "\\text{P[ppprime]}"
   omml:
   - "&#x2034;"
   html:
   - "&#x2034;"
 - unicodemath:
   - pprime
-  - __{''}
-  - __{second}
-  - __{dprime}
+  - '"P{''''}"'
+  - '"P{second}"'
+  - '"P{dprime}"'
   asciimath:
   - "''"
-  - __{pprime}
-  - __{second}
-  - __{dprime}
+  - '"P{pprime}"'
+  - '"P{second}"'
+  - '"P{dprime}"'
   mathml:
   - "&#x2033;"
   latex:
   - second
   - dprime
-  - __{pprime}
-  - __{''}
+  - "\\text{P[pprime]}"
+  - "\\text{P['']}"
   omml:
   - "&#x2033;"
   html:
@@ -11613,24 +11637,24 @@
 - unicodemath:
   - prcue
   - preccurlyeq
-  - __{PrecedesSlantEqual}
+  - '"P{PrecedesSlantEqual}"'
   asciimath:
-  - __{prcue}
-  - __{preccurlyeq}
-  - __{PrecedesSlantEqual}
+  - '"P{prcue}"'
+  - '"P{preccurlyeq}"'
+  - '"P{PrecedesSlantEqual}"'
   mathml:
   - "&#x227c;"
   latex:
   - PrecedesSlantEqual
   - preccurlyeq
-  - __{prcue}
+  - "\\text{P[prcue]}"
   omml:
   - "&#x227c;"
   html:
   - "&#x227c;"
 - unicodemath:
   - prec
-  - __{-<}
+  - '"P{-<}"'
   asciimath:
   - prec
   - "-<"
@@ -11638,15 +11662,15 @@
   - "&#x227a;"
   latex:
   - prec
-  - __{-<}
+  - "\\text{P[-<]}"
   omml:
   - "&#x227a;"
   html:
   - "&#x227a;"
 - unicodemath:
-  - __{precapprox}
+  - '"P{precapprox}"'
   asciimath:
-  - __{precapprox}
+  - '"P{precapprox}"'
   mathml:
   - "&#x2ab7;"
   latex:
@@ -11657,7 +11681,7 @@
   - "&#x2ab7;"
 - unicodemath:
   - preceq
-  - __{-<=}
+  - '"P{-<=}"'
   asciimath:
   - preceq
   - "-<="
@@ -11665,15 +11689,15 @@
   - "&#x2aaf;"
   latex:
   - preceq
-  - __{-<=}
+  - "\\text{P[-<=]}"
   omml:
   - "&#x2aaf;"
   html:
   - "&#x2aaf;"
 - unicodemath:
-  - __{preceqq}
+  - '"P{preceqq}"'
   asciimath:
-  - __{preceqq}
+  - '"P{preceqq}"'
   mathml:
   - "&#x2ab3;"
   latex:
@@ -11683,9 +11707,9 @@
   html:
   - "&#x2ab3;"
 - unicodemath:
-  - __{precnapprox}
+  - '"P{precnapprox}"'
   asciimath:
-  - __{precnapprox}
+  - '"P{precnapprox}"'
   mathml:
   - "&#x2ab9;"
   latex:
@@ -11695,9 +11719,9 @@
   html:
   - "&#x2ab9;"
 - unicodemath:
-  - __{precneq}
+  - '"P{precneq}"'
   asciimath:
-  - __{precneq}
+  - '"P{precneq}"'
   mathml:
   - "&#x2ab1;"
   latex:
@@ -11707,9 +11731,9 @@
   html:
   - "&#x2ab1;"
 - unicodemath:
-  - __{precneqq}
+  - '"P{precneqq}"'
   asciimath:
-  - __{precneqq}
+  - '"P{precneqq}"'
   mathml:
   - "&#x2ab5;"
   latex:
@@ -11721,7 +11745,7 @@
 - unicodemath:
   - precnsim
   asciimath:
-  - __{precnsim}
+  - '"P{precnsim}"'
   mathml:
   - "&#x22e8;"
   latex:
@@ -11732,10 +11756,10 @@
   - "&#x22e8;"
 - unicodemath:
   - precsim
-  - __{PrecedesTilde}
+  - '"P{PrecedesTilde}"'
   asciimath:
-  - __{precsim}
-  - __{PrecedesTilde}
+  - '"P{precsim}"'
+  - '"P{PrecedesTilde}"'
   mathml:
   - "&#x227e;"
   latex:
@@ -11773,9 +11797,9 @@
   html:
   - "&#x220f;"
 - unicodemath:
-  - __{profline}
+  - '"P{profline}"'
   asciimath:
-  - __{profline}
+  - '"P{profline}"'
   mathml:
   - "&#x2312;"
   latex:
@@ -11785,9 +11809,9 @@
   html:
   - "&#x2312;"
 - unicodemath:
-  - __{profsurf}
+  - '"P{profsurf}"'
   asciimath:
-  - __{profsurf}
+  - '"P{profsurf}"'
   mathml:
   - "&#x2313;"
   latex:
@@ -11797,11 +11821,11 @@
   html:
   - "&#x2313;"
 - unicodemath:
-  - __{zproject}
-  - __{project}
+  - '"P{zproject}"'
+  - '"P{project}"'
   asciimath:
-  - __{zproject}
-  - __{project}
+  - '"P{zproject}"'
+  - '"P{project}"'
   mathml:
   - "&#x2a21;"
   latex:
@@ -11814,25 +11838,25 @@
 - unicodemath:
   - propto
   - ratio
-  - __{prop}
+  - '"P{prop}"'
   asciimath:
   - propto
   - prop
-  - __{ratio}
+  - '"P{ratio}"'
   mathml:
   - "&#x221d;"
   latex:
   - propto
-  - __{ratio}
-  - __{prop}
+  - "\\text{P[ratio]}"
+  - "\\text{P[prop]}"
   omml:
   - "&#x221d;"
   html:
   - "&#x221d;"
 - unicodemath:
-  - __{PropertyLine}
+  - '"P{PropertyLine}"'
   asciimath:
-  - __{PropertyLine}
+  - '"P{PropertyLine}"'
   mathml:
   - "&#x214a;"
   latex:
@@ -11843,10 +11867,10 @@
   - "&#x214a;"
 - unicodemath:
   - psi
-  - __{uppsi}
+  - '"P{uppsi}"'
   asciimath:
   - psi
-  - __{uppsi}
+  - '"P{uppsi}"'
   mathml:
   - "&#x3c8;"
   latex:
@@ -11857,13 +11881,13 @@
   html:
   - "&#x3c8;"
 - unicodemath:
-  - __{nvtwoheadrightarrow}
-  - __{psurj}
-  - __{psur}
+  - '"P{nvtwoheadrightarrow}"'
+  - '"P{psurj}"'
+  - '"P{psur}"'
   asciimath:
-  - __{nvtwoheadrightarrow}
-  - __{psurj}
-  - __{psur}
+  - '"P{nvtwoheadrightarrow}"'
+  - '"P{psurj}"'
+  - '"P{psur}"'
   mathml:
   - "&#x2900;"
   latex:
@@ -11875,9 +11899,9 @@
   html:
   - "&#x2900;"
 - unicodemath:
-  - __{pullback}
+  - '"P{pullback}"'
   asciimath:
-  - __{pullback}
+  - '"P{pullback}"'
   mathml:
   - "&#x27d3;"
   latex:
@@ -11887,9 +11911,9 @@
   html:
   - "&#x27d3;"
 - unicodemath:
-  - __{pushout}
+  - '"P{pushout}"'
   asciimath:
-  - __{pushout}
+  - '"P{pushout}"'
   mathml:
   - "&#x27d4;"
   latex:
@@ -11900,25 +11924,25 @@
   - "&#x27d4;"
 - unicodemath:
   - qed
-  - __{QED}
+  - '"P{QED}"'
   asciimath:
-  - __{qed}
-  - __{QED}
+  - '"P{qed}"'
+  - '"P{QED}"'
   mathml:
   - "&#x220e;"
   latex:
   - QED
-  - __{qed}
+  - "\\text{P[qed]}"
   omml:
   - "&#x220e;"
   html:
   - "&#x220e;"
 - unicodemath:
-  - __{fourth}
-  - __{qprime}
+  - '"P{fourth}"'
+  - '"P{qprime}"'
   asciimath:
-  - __{fourth}
-  - __{qprime}
+  - '"P{fourth}"'
+  - '"P{qprime}"'
   mathml:
   - "&#x2057;"
   latex:
@@ -11929,9 +11953,9 @@
   html:
   - "&#x2057;"
 - unicodemath:
-  - __{QQ}
+  - '"P{QQ}"'
   asciimath:
-  - __{QQ}
+  - '"P{QQ}"'
   mathml:
   - "&#x211a;"
   latex:
@@ -11941,9 +11965,9 @@
   html:
   - "&#x211a;"
 - unicodemath:
-  - __{qquad}
+  - '"P{qquad}"'
   asciimath:
-  - __{qquad}
+  - '"P{qquad}"'
   mathml:
   - "&#xa0;&#xa0;&#xa0;&#xa0;"
   latex:
@@ -11962,9 +11986,9 @@
   omml: []
   html: []
 - unicodemath:
-  - __{quarternote}
+  - '"P{quarternote}"'
   asciimath:
-  - __{quarternote}
+  - '"P{quarternote}"'
   mathml:
   - "&#x2669;"
   latex:
@@ -11974,9 +11998,9 @@
   html:
   - "&#x2669;"
 - unicodemath:
-  - __{questeq}
+  - '"P{questeq}"'
   asciimath:
-  - __{questeq}
+  - '"P{questeq}"'
   mathml:
   - "&#x225f;"
   latex:
@@ -11987,10 +12011,10 @@
   - "&#x225f;"
 - unicodemath:
   - "?"
-  - __{question}
+  - '"P{question}"'
   asciimath:
   - "?"
-  - __{question}
+  - '"P{question}"'
   mathml:
   - "&#x3f;"
   latex:
@@ -12001,9 +12025,9 @@
   html:
   - "&#x3f;"
 - unicodemath:
-  - __{radiation}
+  - '"P{radiation}"'
   asciimath:
-  - __{radiation}
+  - '"P{radiation}"'
   mathml:
   - "&#x2622;"
   latex:
@@ -12013,11 +12037,11 @@
   html:
   - "&#x2622;"
 - unicodemath:
-  - __{rAngle}
-  - __{rang}
+  - '"P{rAngle}"'
+  - '"P{rang}"'
   asciimath:
-  - __{rAngle}
-  - __{rang}
+  - '"P{rAngle}"'
+  - '"P{rang}"'
   mathml:
   - "&#x27eb;"
   latex:
@@ -12028,9 +12052,9 @@
   html:
   - "&#x27eb;"
 - unicodemath:
-  - __{rangledot}
+  - '"P{rangledot}"'
   asciimath:
-  - __{rangledot}
+  - '"P{rangledot}"'
   mathml:
   - "&#x2992;"
   latex:
@@ -12040,9 +12064,9 @@
   html:
   - "&#x2992;"
 - unicodemath:
-  - __{rangledownzigzagarrow}
+  - '"P{rangledownzigzagarrow}"'
   asciimath:
-  - __{rangledownzigzagarrow}
+  - '"P{rangledownzigzagarrow}"'
   mathml:
   - "&#x237c;"
   latex:
@@ -12054,27 +12078,27 @@
 - unicodemath:
   - propto
   - ratio
-  - __{prop}
+  - '"P{prop}"'
   asciimath:
   - propto
   - prop
-  - __{ratio}
+  - '"P{ratio}"'
   mathml:
   - "&#x221d;"
   latex:
   - propto
-  - __{ratio}
-  - __{prop}
+  - "\\text{P[ratio]}"
+  - "\\text{P[prop]}"
   omml:
   - "&#x221d;"
   html:
   - "&#x221d;"
 - unicodemath:
-  - __{Rbag}
-  - __{rbag}
+  - '"P{Rbag}"'
+  - '"P{rbag}"'
   asciimath:
-  - __{Rbag}
-  - __{rbag}
+  - '"P{Rbag}"'
+  - '"P{rbag}"'
   mathml:
   - "&#x27c6;"
   latex:
@@ -12085,9 +12109,9 @@
   html:
   - "&#x27c6;"
 - unicodemath:
-  - __{rblkbrbrak}
+  - '"P{rblkbrbrak}"'
   asciimath:
-  - __{rblkbrbrak}
+  - '"P{rblkbrbrak}"'
   mathml:
   - "&#x2998;"
   latex:
@@ -12097,11 +12121,11 @@
   html:
   - "&#x2998;"
 - unicodemath:
-  - __{rrangle}
-  - __{rblot}
+  - '"P{rrangle}"'
+  - '"P{rblot}"'
   asciimath:
-  - __{rrangle}
-  - __{rblot}
+  - '"P{rrangle}"'
+  - '"P{rblot}"'
   mathml:
   - "&#x298a;"
   latex:
@@ -12112,9 +12136,9 @@
   html:
   - "&#x298a;"
 - unicodemath:
-  - __{rbracelend}
+  - '"P{rbracelend}"'
   asciimath:
-  - __{rbracelend}
+  - '"P{rbracelend}"'
   mathml:
   - "&#x23ad;"
   latex:
@@ -12124,9 +12148,9 @@
   html:
   - "&#x23ad;"
 - unicodemath:
-  - __{rbracemid}
+  - '"P{rbracemid}"'
   asciimath:
-  - __{rbracemid}
+  - '"P{rbracemid}"'
   mathml:
   - "&#x23ac;"
   latex:
@@ -12136,9 +12160,9 @@
   html:
   - "&#x23ac;"
 - unicodemath:
-  - __{rbraceuend}
+  - '"P{rbraceuend}"'
   asciimath:
-  - __{rbraceuend}
+  - '"P{rbraceuend}"'
   mathml:
   - "&#x23ab;"
   latex:
@@ -12148,9 +12172,9 @@
   html:
   - "&#x23ab;"
 - unicodemath:
-  - __{rbrackextender}
+  - '"P{rbrackextender}"'
   asciimath:
-  - __{rbrackextender}
+  - '"P{rbrackextender}"'
   mathml:
   - "&#x23a5;"
   latex:
@@ -12160,9 +12184,9 @@
   html:
   - "&#x23a5;"
 - unicodemath:
-  - __{rbracklend}
+  - '"P{rbracklend}"'
   asciimath:
-  - __{rbracklend}
+  - '"P{rbracklend}"'
   mathml:
   - "&#x23a6;"
   latex:
@@ -12172,9 +12196,9 @@
   html:
   - "&#x23a6;"
 - unicodemath:
-  - __{rbracklrtick}
+  - '"P{rbracklrtick}"'
   asciimath:
-  - __{rbracklrtick}
+  - '"P{rbracklrtick}"'
   mathml:
   - "&#x298e;"
   latex:
@@ -12184,9 +12208,9 @@
   html:
   - "&#x298e;"
 - unicodemath:
-  - __{rbrackubar}
+  - '"P{rbrackubar}"'
   asciimath:
-  - __{rbrackubar}
+  - '"P{rbrackubar}"'
   mathml:
   - "&#x298c;"
   latex:
@@ -12196,9 +12220,9 @@
   html:
   - "&#x298c;"
 - unicodemath:
-  - __{rbrackuend}
+  - '"P{rbrackuend}"'
   asciimath:
-  - __{rbrackuend}
+  - '"P{rbrackuend}"'
   mathml:
   - "&#x23a4;"
   latex:
@@ -12208,9 +12232,9 @@
   html:
   - "&#x23a4;"
 - unicodemath:
-  - __{rbrackurtick}
+  - '"P{rbrackurtick}"'
   asciimath:
-  - __{rbrackurtick}
+  - '"P{rbrackurtick}"'
   mathml:
   - "&#x2990;"
   latex:
@@ -12220,9 +12244,9 @@
   html:
   - "&#x2990;"
 - unicodemath:
-  - __{Rbrbrak}
+  - '"P{Rbrbrak}"'
   asciimath:
-  - __{Rbrbrak}
+  - '"P{Rbrbrak}"'
   mathml:
   - "&#x27ed;"
   latex:
@@ -12232,9 +12256,9 @@
   html:
   - "&#x27ed;"
 - unicodemath:
-  - __{rcurvyangle}
+  - '"P{rcurvyangle}"'
   asciimath:
-  - __{rcurvyangle}
+  - '"P{rcurvyangle}"'
   mathml:
   - "&#x29fd;"
   latex:
@@ -12245,26 +12269,26 @@
   - "&#x29fd;"
 - unicodemath:
   - rddots
-  - __{iddots}
-  - __{adots}
+  - '"P{iddots}"'
+  - '"P{adots}"'
   asciimath:
-  - __{rddots}
-  - __{iddots}
-  - __{adots}
+  - '"P{rddots}"'
+  - '"P{iddots}"'
+  - '"P{adots}"'
   mathml:
   - "&#x22f0;"
   latex:
   - iddots
   - adots
-  - __{rddots}
+  - "\\text{P[rddots]}"
   omml:
   - "&#x22f0;"
   html:
   - "&#x22f0;"
 - unicodemath:
-  - __{rdiagovfdiag}
+  - '"P{rdiagovfdiag}"'
   asciimath:
-  - __{rdiagovfdiag}
+  - '"P{rdiagovfdiag}"'
   mathml:
   - "&#x292b;"
   latex:
@@ -12274,9 +12298,9 @@
   html:
   - "&#x292b;"
 - unicodemath:
-  - __{rdiagovsearrow}
+  - '"P{rdiagovsearrow}"'
   asciimath:
-  - __{rdiagovsearrow}
+  - '"P{rdiagovsearrow}"'
   mathml:
   - "&#x2930;"
   latex:
@@ -12287,18 +12311,18 @@
   - "&#x2930;"
 - unicodemath:
   - rdsh
-  - __{drsh}
-  - __{Rdsh}
+  - '"P{drsh}"'
+  - '"P{Rdsh}"'
   asciimath:
-  - __{rdsh}
-  - __{drsh}
-  - __{Rdsh}
+  - '"P{rdsh}"'
+  - '"P{drsh}"'
+  - '"P{Rdsh}"'
   mathml:
   - "&#x21b3;"
   latex:
   - drsh
   - Rdsh
-  - __{rdsh}
+  - "\\text{P[rdsh]}"
   omml:
   - "&#x21b3;"
   html:
@@ -12306,7 +12330,7 @@
 - unicodemath:
   - Re
   asciimath:
-  - __{Re}
+  - '"P{Re}"'
   mathml:
   - "&#x211c;"
   latex:
@@ -12316,9 +12340,9 @@
   html:
   - "&#x211c;"
 - unicodemath:
-  - __{recycle}
+  - '"P{recycle}"'
   asciimath:
-  - __{recycle}
+  - '"P{recycle}"'
   mathml:
   - "&#x267b;"
   latex:
@@ -12329,28 +12353,28 @@
   - "&#x267b;"
 - unicodemath:
   - leftrightarrow
-  - __{harr}
-  - __{rel}
+  - '"P{harr}"'
+  - '"P{rel}"'
   asciimath:
   - leftrightarrow
   - harr
-  - __{rel}
+  - '"P{rel}"'
   mathml:
   - "&#x2194;"
   latex:
   - leftrightarrow
   - rel
-  - __{harr}
+  - "\\text{P[harr]}"
   omml:
   - "&#x2194;"
   html:
   - "&#x2194;"
 - unicodemath:
   - upharpoonright
-  - __{restriction}
+  - '"P{restriction}"'
   asciimath:
-  - __{upharpoonright}
-  - __{restriction}
+  - '"P{upharpoonright}"'
+  - '"P{restriction}"'
   mathml:
   - "&#x21be;"
   latex:
@@ -12361,9 +12385,9 @@
   html:
   - "&#x21be;"
 - unicodemath:
-  - __{revangle}
+  - '"P{revangle}"'
   asciimath:
-  - __{revangle}
+  - '"P{revangle}"'
   mathml:
   - "&#x29a3;"
   latex:
@@ -12373,9 +12397,9 @@
   html:
   - "&#x29a3;"
 - unicodemath:
-  - __{revangleubar}
+  - '"P{revangleubar}"'
   asciimath:
-  - __{revangleubar}
+  - '"P{revangleubar}"'
   mathml:
   - "&#x29a5;"
   latex:
@@ -12385,9 +12409,9 @@
   html:
   - "&#x29a5;"
 - unicodemath:
-  - __{revemptyset}
+  - '"P{revemptyset}"'
   asciimath:
-  - __{revemptyset}
+  - '"P{revemptyset}"'
   mathml:
   - "&#x29b0;"
   latex:
@@ -12397,9 +12421,9 @@
   html:
   - "&#x29b0;"
 - unicodemath:
-  - __{revnmid}
+  - '"P{revnmid}"'
   asciimath:
-  - __{revnmid}
+  - '"P{revnmid}"'
   mathml:
   - "&#x2aee;"
   latex:
@@ -12409,9 +12433,9 @@
   html:
   - "&#x2aee;"
 - unicodemath:
-  - __{rfbowtie}
+  - '"P{rfbowtie}"'
   asciimath:
-  - __{rfbowtie}
+  - '"P{rfbowtie}"'
   mathml:
   - "&#x29d2;"
   latex:
@@ -12421,9 +12445,9 @@
   html:
   - "&#x29d2;"
 - unicodemath:
-  - __{rftimes}
+  - '"P{rftimes}"'
   asciimath:
-  - __{rftimes}
+  - '"P{rftimes}"'
   mathml:
   - "&#x29d5;"
   latex:
@@ -12433,9 +12457,9 @@
   html:
   - "&#x29d5;"
 - unicodemath:
-  - __{rgroup}
+  - '"P{rgroup}"'
   asciimath:
-  - __{rgroup}
+  - '"P{rgroup}"'
   mathml:
   - "&#x27ef;"
   latex:
@@ -12445,13 +12469,13 @@
   html:
   - "&#x27ef;"
 - unicodemath:
-  - __{triangleright}
-  - __{rres}
-  - __{rhd}
+  - '"P{triangleright}"'
+  - '"P{rres}"'
+  - '"P{rhd}"'
   asciimath:
-  - __{triangleright}
-  - __{rres}
-  - __{rhd}
+  - '"P{triangleright}"'
+  - '"P{rres}"'
+  - '"P{rhd}"'
   mathml:
   - "&#x25b7;"
   latex:
@@ -12464,10 +12488,10 @@
   - "&#x25b7;"
 - unicodemath:
   - rho
-  - __{uprho}
+  - '"P{uprho}"'
   asciimath:
   - rho
-  - __{uprho}
+  - '"P{uprho}"'
   mathml:
   - "&#x3c1;"
   latex:
@@ -12480,25 +12504,25 @@
 - unicodemath:
   - rightangle
   - angle
-  - __{/_}
+  - '"P{/_}"'
   asciimath:
   - angle
   - "/_"
-  - __{rightangle}
+  - '"P{rightangle}"'
   mathml:
   - "&#x2220;"
   latex:
   - angle
-  - __{rightangle}
-  - __{/_}
+  - "\\text{P[rightangle]}"
+  - "\\text{P[/_]}"
   omml:
   - "&#x2220;"
   html:
   - "&#x2220;"
 - unicodemath:
-  - __{rightanglemdot}
+  - '"P{rightanglemdot}"'
   asciimath:
-  - __{rightanglemdot}
+  - '"P{rightanglemdot}"'
   mathml:
   - "&#x299d;"
   latex:
@@ -12508,9 +12532,9 @@
   html:
   - "&#x299d;"
 - unicodemath:
-  - __{rightanglesqr}
+  - '"P{rightanglesqr}"'
   asciimath:
-  - __{rightanglesqr}
+  - '"P{rightanglesqr}"'
   mathml:
   - "&#x299c;"
   latex:
@@ -12522,8 +12546,8 @@
 - unicodemath:
   - rightarrow
   - to
-  - __{rarr}
-  - __{->}
+  - '"P{rarr}"'
+  - '"P{->}"'
   asciimath:
   - rightarrow
   - rarr
@@ -12534,16 +12558,16 @@
   latex:
   - rightarrow
   - to
-  - __{rarr}
-  - __{->}
+  - "\\text{P[rarr]}"
+  - "\\text{P[->]}"
   omml:
   - "&#x2192;"
   html:
   - "&#x2192;"
 - unicodemath:
-  - __{rightarrowapprox}
+  - '"P{rightarrowapprox}"'
   asciimath:
-  - __{rightarrowapprox}
+  - '"P{rightarrowapprox}"'
   mathml:
   - "&#x2975;"
   latex:
@@ -12553,9 +12577,9 @@
   html:
   - "&#x2975;"
 - unicodemath:
-  - __{rightarrowbackapprox}
+  - '"P{rightarrowbackapprox}"'
   asciimath:
-  - __{rightarrowbackapprox}
+  - '"P{rightarrowbackapprox}"'
   mathml:
   - "&#x2b48;"
   latex:
@@ -12565,11 +12589,11 @@
   html:
   - "&#x2b48;"
 - unicodemath:
-  - __{RightArrowBar}
-  - __{rightarrowbar}
+  - '"P{RightArrowBar}"'
+  - '"P{rightarrowbar}"'
   asciimath:
-  - __{RightArrowBar}
-  - __{rightarrowbar}
+  - '"P{RightArrowBar}"'
+  - '"P{rightarrowbar}"'
   mathml:
   - "&#x21e5;"
   latex:
@@ -12580,9 +12604,9 @@
   html:
   - "&#x21e5;"
 - unicodemath:
-  - __{rightarrowbsimilar}
+  - '"P{rightarrowbsimilar}"'
   asciimath:
-  - __{rightarrowbsimilar}
+  - '"P{rightarrowbsimilar}"'
   mathml:
   - "&#x2b4c;"
   latex:
@@ -12592,9 +12616,9 @@
   html:
   - "&#x2b4c;"
 - unicodemath:
-  - __{rightarrowdiamond}
+  - '"P{rightarrowdiamond}"'
   asciimath:
-  - __{rightarrowdiamond}
+  - '"P{rightarrowdiamond}"'
   mathml:
   - "&#x291e;"
   latex:
@@ -12604,9 +12628,9 @@
   html:
   - "&#x291e;"
 - unicodemath:
-  - __{rightarrowgtr}
+  - '"P{rightarrowgtr}"'
   asciimath:
-  - __{rightarrowgtr}
+  - '"P{rightarrowgtr}"'
   mathml:
   - "&#x2b43;"
   latex:
@@ -12616,9 +12640,9 @@
   html:
   - "&#x2b43;"
 - unicodemath:
-  - __{rightarrowonoplus}
+  - '"P{rightarrowonoplus}"'
   asciimath:
-  - __{rightarrowonoplus}
+  - '"P{rightarrowonoplus}"'
   mathml:
   - "&#x27f4;"
   latex:
@@ -12628,9 +12652,9 @@
   html:
   - "&#x27f4;"
 - unicodemath:
-  - __{rightarrowplus}
+  - '"P{rightarrowplus}"'
   asciimath:
-  - __{rightarrowplus}
+  - '"P{rightarrowplus}"'
   mathml:
   - "&#x2945;"
   latex:
@@ -12640,9 +12664,9 @@
   html:
   - "&#x2945;"
 - unicodemath:
-  - __{rightarrowshortleftarrow}
+  - '"P{rightarrowshortleftarrow}"'
   asciimath:
-  - __{rightarrowshortleftarrow}
+  - '"P{rightarrowshortleftarrow}"'
   mathml:
   - "&#x2942;"
   latex:
@@ -12652,9 +12676,9 @@
   html:
   - "&#x2942;"
 - unicodemath:
-  - __{rightarrowsimilar}
+  - '"P{rightarrowsimilar}"'
   asciimath:
-  - __{rightarrowsimilar}
+  - '"P{rightarrowsimilar}"'
   mathml:
   - "&#x2974;"
   latex:
@@ -12664,9 +12688,9 @@
   html:
   - "&#x2974;"
 - unicodemath:
-  - __{rightarrowsupset}
+  - '"P{rightarrowsupset}"'
   asciimath:
-  - __{rightarrowsupset}
+  - '"P{rightarrowsupset}"'
   mathml:
   - "&#x2b44;"
   latex:
@@ -12677,26 +12701,26 @@
   - "&#x2b44;"
 - unicodemath:
   - rightarrowtail
-  - __{>->}
-  - __{tinj}
+  - '"P{>->}"'
+  - '"P{tinj}"'
   asciimath:
   - rightarrowtail
   - ">->"
-  - __{tinj}
+  - '"P{tinj}"'
   mathml:
   - "&#x21a3;"
   latex:
   - rightarrowtail
   - tinj
-  - __{>->}
+  - "\\text{P[>->]}"
   omml:
   - "&#x21a3;"
   html:
   - "&#x21a3;"
 - unicodemath:
-  - __{rightarrowtriangle}
+  - '"P{rightarrowtriangle}"'
   asciimath:
-  - __{rightarrowtriangle}
+  - '"P{rightarrowtriangle}"'
   mathml:
   - "&#x21fe;"
   latex:
@@ -12706,9 +12730,9 @@
   html:
   - "&#x21fe;"
 - unicodemath:
-  - __{rightarrowx}
+  - '"P{rightarrowx}"'
   asciimath:
-  - __{rightarrowx}
+  - '"P{rightarrowx}"'
   mathml:
   - "&#x2947;"
   latex:
@@ -12718,11 +12742,11 @@
   html:
   - "&#x2947;"
 - unicodemath:
-  - __{rightharpoonupdash}
-  - __{rightbarharpoon}
+  - '"P{rightharpoonupdash}"'
+  - '"P{rightbarharpoon}"'
   asciimath:
-  - __{rightharpoonupdash}
-  - __{rightbarharpoon}
+  - '"P{rightharpoonupdash}"'
+  - '"P{rightbarharpoon}"'
   mathml:
   - "&#x296c;"
   latex:
@@ -12733,9 +12757,9 @@
   html:
   - "&#x296c;"
 - unicodemath:
-  - __{rightbkarrow}
+  - '"P{rightbkarrow}"'
   asciimath:
-  - __{rightbkarrow}
+  - '"P{rightbkarrow}"'
   mathml:
   - "&#x290d;"
   latex:
@@ -12745,11 +12769,11 @@
   html:
   - "&#x290d;"
 - unicodemath:
-  - __{blackrighthalfcircle}
-  - __{RIGHTCIRCLE}
+  - '"P{blackrighthalfcircle}"'
+  - '"P{RIGHTCIRCLE}"'
   asciimath:
-  - __{blackrighthalfcircle}
-  - __{RIGHTCIRCLE}
+  - '"P{blackrighthalfcircle}"'
+  - '"P{RIGHTCIRCLE}"'
   mathml:
   - "&#x25d7;"
   latex:
@@ -12760,9 +12784,9 @@
   html:
   - "&#x25d7;"
 - unicodemath:
-  - __{rightdbltail}
+  - '"P{rightdbltail}"'
   asciimath:
-  - __{rightdbltail}
+  - '"P{rightdbltail}"'
   mathml:
   - "&#x291c;"
   latex:
@@ -12772,9 +12796,9 @@
   html:
   - "&#x291c;"
 - unicodemath:
-  - __{rightdotarrow}
+  - '"P{rightdotarrow}"'
   asciimath:
-  - __{rightdotarrow}
+  - '"P{rightdotarrow}"'
   mathml:
   - "&#x2911;"
   latex:
@@ -12784,9 +12808,9 @@
   html:
   - "&#x2911;"
 - unicodemath:
-  - __{rightdowncurvedarrow}
+  - '"P{rightdowncurvedarrow}"'
   asciimath:
-  - __{rightdowncurvedarrow}
+  - '"P{rightdowncurvedarrow}"'
   mathml:
   - "&#x2937;"
   latex:
@@ -12796,11 +12820,11 @@
   html:
   - "&#x2937;"
 - unicodemath:
-  - __{bardownharpoonright}
-  - __{RightDownTeeVector}
+  - '"P{bardownharpoonright}"'
+  - '"P{RightDownTeeVector}"'
   asciimath:
-  - __{bardownharpoonright}
-  - __{RightDownTeeVector}
+  - '"P{bardownharpoonright}"'
+  - '"P{RightDownTeeVector}"'
   mathml:
   - "&#x295d;"
   latex:
@@ -12811,11 +12835,11 @@
   html:
   - "&#x295d;"
 - unicodemath:
-  - __{downharpoonrightbar}
-  - __{RightDownVectorBar}
+  - '"P{downharpoonrightbar}"'
+  - '"P{RightDownVectorBar}"'
   asciimath:
-  - __{downharpoonrightbar}
-  - __{RightDownVectorBar}
+  - '"P{downharpoonrightbar}"'
+  - '"P{RightDownVectorBar}"'
   mathml:
   - "&#x2955;"
   latex:
@@ -12826,9 +12850,9 @@
   html:
   - "&#x2955;"
 - unicodemath:
-  - __{rightharpoonaccent}
+  - '"P{rightharpoonaccent}"'
   asciimath:
-  - __{rightharpoonaccent}
+  - '"P{rightharpoonaccent}"'
   mathml:
   - "&#x20d1;"
   latex:
@@ -12840,7 +12864,7 @@
 - unicodemath:
   - rightharpoondown
   asciimath:
-  - __{rightharpoondown}
+  - '"P{rightharpoondown}"'
   mathml:
   - "&#x21c1;"
   latex:
@@ -12852,7 +12876,7 @@
 - unicodemath:
   - rightharpoonup
   asciimath:
-  - __{rightharpoonup}
+  - '"P{rightharpoonup}"'
   mathml:
   - "&#x21c0;"
   latex:
@@ -12862,9 +12886,9 @@
   html:
   - "&#x21c0;"
 - unicodemath:
-  - __{rightimply}
+  - '"P{rightimply}"'
   asciimath:
-  - __{rightimply}
+  - '"P{rightimply}"'
   mathml:
   - "&#x2970;"
   latex:
@@ -12875,10 +12899,10 @@
   - "&#x2970;"
 - unicodemath:
   - rightleftarrows
-  - __{rightleftarrow}
+  - '"P{rightleftarrow}"'
   asciimath:
-  - __{rightleftarrows}
-  - __{rightleftarrow}
+  - '"P{rightleftarrows}"'
+  - '"P{rightleftarrow}"'
   mathml:
   - "&#x21c4;"
   latex:
@@ -12889,11 +12913,11 @@
   html:
   - "&#x21c4;"
 - unicodemath:
-  - __{leftrightharpoondownup}
-  - __{rightleftharpoon}
+  - '"P{leftrightharpoondownup}"'
+  - '"P{rightleftharpoon}"'
   asciimath:
-  - __{leftrightharpoondownup}
-  - __{rightleftharpoon}
+  - '"P{leftrightharpoondownup}"'
+  - '"P{rightleftharpoon}"'
   mathml:
   - "&#x294b;"
   latex:
@@ -12904,9 +12928,9 @@
   html:
   - "&#x294b;"
 - unicodemath:
-  - __{rightleftharpoonsdown}
+  - '"P{rightleftharpoonsdown}"'
   asciimath:
-  - __{rightleftharpoonsdown}
+  - '"P{rightleftharpoonsdown}"'
   mathml:
   - "&#x2969;"
   latex:
@@ -12916,9 +12940,9 @@
   html:
   - "&#x2969;"
 - unicodemath:
-  - __{rightleftharpoonsup}
+  - '"P{rightleftharpoonsup}"'
   asciimath:
-  - __{rightleftharpoonsup}
+  - '"P{rightleftharpoonsup}"'
   mathml:
   - "&#x2968;"
   latex:
@@ -12928,9 +12952,9 @@
   html:
   - "&#x2968;"
 - unicodemath:
-  - __{rightmoon}
+  - '"P{rightmoon}"'
   asciimath:
-  - __{rightmoon}
+  - '"P{rightmoon}"'
   mathml:
   - "&#x263d;"
   latex:
@@ -12940,9 +12964,9 @@
   html:
   - "&#x263d;"
 - unicodemath:
-  - __{rightouterjoin}
+  - '"P{rightouterjoin}"'
   asciimath:
-  - __{rightouterjoin}
+  - '"P{rightouterjoin}"'
   mathml:
   - "&#x27d6;"
   latex:
@@ -12952,9 +12976,9 @@
   html:
   - "&#x27d6;"
 - unicodemath:
-  - __{rightpentagon}
+  - '"P{rightpentagon}"'
   asciimath:
-  - __{rightpentagon}
+  - '"P{rightpentagon}"'
   mathml:
   - "&#x2b54;"
   latex:
@@ -12964,9 +12988,9 @@
   html:
   - "&#x2b54;"
 - unicodemath:
-  - __{rightpentagonblack}
+  - '"P{rightpentagonblack}"'
   asciimath:
-  - __{rightpentagonblack}
+  - '"P{rightpentagonblack}"'
   mathml:
   - "&#x2b53;"
   latex:
@@ -12978,7 +13002,7 @@
 - unicodemath:
   - rightrightarrows
   asciimath:
-  - __{rightrightarrows}
+  - '"P{rightrightarrows}"'
   mathml:
   - "&#x21c9;"
   latex:
@@ -12988,11 +13012,11 @@
   html:
   - "&#x21c9;"
 - unicodemath:
-  - __{rightharpoonsupdown}
-  - __{rightrightharpoons}
+  - '"P{rightharpoonsupdown}"'
+  - '"P{rightrightharpoons}"'
   asciimath:
-  - __{rightharpoonsupdown}
-  - __{rightrightharpoons}
+  - '"P{rightharpoonsupdown}"'
+  - '"P{rightrightharpoons}"'
   mathml:
   - "&#x2964;"
   latex:
@@ -13005,7 +13029,7 @@
 - unicodemath:
   - rightsquigarrow
   asciimath:
-  - __{rightsquigarrow}
+  - '"P{rightsquigarrow}"'
   mathml:
   - "&#x21dd;"
   latex:
@@ -13015,9 +13039,9 @@
   html:
   - "&#x21dd;"
 - unicodemath:
-  - __{righttail}
+  - '"P{righttail}"'
   asciimath:
-  - __{righttail}
+  - '"P{righttail}"'
   mathml:
   - "&#x291a;"
   latex:
@@ -13027,11 +13051,11 @@
   html:
   - "&#x291a;"
 - unicodemath:
-  - __{barrightharpoonup}
-  - __{RightTeeVector}
+  - '"P{barrightharpoonup}"'
+  - '"P{RightTeeVector}"'
   asciimath:
-  - __{barrightharpoonup}
-  - __{RightTeeVector}
+  - '"P{barrightharpoonup}"'
+  - '"P{RightTeeVector}"'
   mathml:
   - "&#x295b;"
   latex:
@@ -13042,9 +13066,9 @@
   html:
   - "&#x295b;"
 - unicodemath:
-  - __{rightthreearrows}
+  - '"P{rightthreearrows}"'
   asciimath:
-  - __{rightthreearrows}
+  - '"P{rightthreearrows}"'
   mathml:
   - "&#x21f6;"
   latex:
@@ -13056,7 +13080,7 @@
 - unicodemath:
   - rightthreetimes
   asciimath:
-  - __{rightthreetimes}
+  - '"P{rightthreetimes}"'
   mathml:
   - "&#x22cc;"
   latex:
@@ -13067,12 +13091,12 @@
   - "&#x22cc;"
 - unicodemath:
   - circlearrowright
-  - __{cwopencirclearrow}
-  - __{rightturn}
+  - '"P{cwopencirclearrow}"'
+  - '"P{rightturn}"'
   asciimath:
-  - __{circlearrowright}
-  - __{cwopencirclearrow}
-  - __{rightturn}
+  - '"P{circlearrowright}"'
+  - '"P{cwopencirclearrow}"'
+  - '"P{rightturn}"'
   mathml:
   - "&#x21bb;"
   latex:
@@ -13084,11 +13108,11 @@
   html:
   - "&#x21bb;"
 - unicodemath:
-  - __{updownharpoonrightright}
-  - __{rightupdownharpoon}
+  - '"P{updownharpoonrightright}"'
+  - '"P{rightupdownharpoon}"'
   asciimath:
-  - __{updownharpoonrightright}
-  - __{rightupdownharpoon}
+  - '"P{updownharpoonrightright}"'
+  - '"P{rightupdownharpoon}"'
   mathml:
   - "&#x294f;"
   latex:
@@ -13099,11 +13123,11 @@
   html:
   - "&#x294f;"
 - unicodemath:
-  - __{upharpoonrightbar}
-  - __{RightUpTeeVector}
+  - '"P{upharpoonrightbar}"'
+  - '"P{RightUpTeeVector}"'
   asciimath:
-  - __{upharpoonrightbar}
-  - __{RightUpTeeVector}
+  - '"P{upharpoonrightbar}"'
+  - '"P{RightUpTeeVector}"'
   mathml:
   - "&#x295c;"
   latex:
@@ -13114,11 +13138,11 @@
   html:
   - "&#x295c;"
 - unicodemath:
-  - __{barupharpoonright}
-  - __{RightUpVectorBar}
+  - '"P{barupharpoonright}"'
+  - '"P{RightUpVectorBar}"'
   asciimath:
-  - __{barupharpoonright}
-  - __{RightUpVectorBar}
+  - '"P{barupharpoonright}"'
+  - '"P{RightUpVectorBar}"'
   mathml:
   - "&#x2954;"
   latex:
@@ -13129,11 +13153,11 @@
   html:
   - "&#x2954;"
 - unicodemath:
-  - __{rightharpoonupbar}
-  - __{RightVectorBar}
+  - '"P{rightharpoonupbar}"'
+  - '"P{RightVectorBar}"'
   asciimath:
-  - __{rightharpoonupbar}
-  - __{RightVectorBar}
+  - '"P{rightharpoonupbar}"'
+  - '"P{RightVectorBar}"'
   mathml:
   - "&#x2953;"
   latex:
@@ -13146,7 +13170,7 @@
 - unicodemath:
   - rightwavearrow
   asciimath:
-  - __{rightwavearrow}
+  - '"P{rightwavearrow}"'
   mathml:
   - "&#x219d;"
   latex:
@@ -13156,9 +13180,9 @@
   html:
   - "&#x219d;"
 - unicodemath:
-  - __{rightwhitearrow}
+  - '"P{rightwhitearrow}"'
   asciimath:
-  - __{rightwhitearrow}
+  - '"P{rightwhitearrow}"'
   mathml:
   - "&#x21e8;"
   latex:
@@ -13168,11 +13192,11 @@
   html:
   - "&#x21e8;"
 - unicodemath:
-  - __{rrparenthesis}
-  - __{rimg}
+  - '"P{rrparenthesis}"'
+  - '"P{rimg}"'
   asciimath:
-  - __{rrparenthesis}
-  - __{rimg}
+  - '"P{rrparenthesis}"'
+  - '"P{rimg}"'
   mathml:
   - "&#x2988;"
   latex:
@@ -13183,13 +13207,13 @@
   html:
   - "&#x2988;"
 - unicodemath:
-  - __{mathring}
-  - __{ocirc}
-  - __{ring}
+  - '"P{mathring}"'
+  - '"P{ocirc}"'
+  - '"P{ring}"'
   asciimath:
-  - __{mathring}
-  - __{ocirc}
-  - __{ring}
+  - '"P{mathring}"'
+  - '"P{ocirc}"'
+  - '"P{ring}"'
   mathml:
   - "&#x30a;"
   latex:
@@ -13201,9 +13225,9 @@
   html:
   - "&#x30a;"
 - unicodemath:
-  - __{ringplus}
+  - '"P{ringplus}"'
   asciimath:
-  - __{ringplus}
+  - '"P{ringplus}"'
   mathml:
   - "&#x2a22;"
   latex:
@@ -13215,7 +13239,7 @@
 - unicodemath:
   - risingdotseq
   asciimath:
-  - __{risingdotseq}
+  - '"P{risingdotseq}"'
   mathml:
   - "&#x2253;"
   latex:
@@ -13227,40 +13251,40 @@
 - unicodemath:
   - rightleftharpoons
   - rlhar
-  - __{equilibrium}
+  - '"P{equilibrium}"'
   asciimath:
-  - __{rightleftharpoons}
-  - __{rlhar}
-  - __{equilibrium}
+  - '"P{rightleftharpoons}"'
+  - '"P{rlhar}"'
+  - '"P{equilibrium}"'
   mathml:
   - "&#x21cc;"
   latex:
   - rightleftharpoons
   - equilibrium
-  - __{rlhar}
+  - "\\text{P[rlhar]}"
   omml:
   - "&#x21cc;"
   html:
   - "&#x21cc;"
 - unicodemath:
   - rmoust
-  - __{rmoustache}
+  - '"P{rmoustache}"'
   asciimath:
-  - __{rmoust}
-  - __{rmoustache}
+  - '"P{rmoust}"'
+  - '"P{rmoustache}"'
   mathml:
   - "&#x23b1;"
   latex:
   - rmoustache
-  - __{rmoust}
+  - "\\text{P[rmoust]}"
   omml:
   - "&#x23b1;"
   html:
   - "&#x23b1;"
 - unicodemath:
-  - __{rparen}
+  - '"P{rparen}"'
   asciimath:
-  - __{rparen}
+  - '"P{rparen}"'
   mathml:
   - "&#x29;"
   latex:
@@ -13270,9 +13294,9 @@
   html:
   - "&#x29;"
 - unicodemath:
-  - __{rparenextender}
+  - '"P{rparenextender}"'
   asciimath:
-  - __{rparenextender}
+  - '"P{rparenextender}"'
   mathml:
   - "&#x239f;"
   latex:
@@ -13282,9 +13306,9 @@
   html:
   - "&#x239f;"
 - unicodemath:
-  - __{rparengtr}
+  - '"P{rparengtr}"'
   asciimath:
-  - __{rparengtr}
+  - '"P{rparengtr}"'
   mathml:
   - "&#x2994;"
   latex:
@@ -13294,9 +13318,9 @@
   html:
   - "&#x2994;"
 - unicodemath:
-  - __{rparenlend}
+  - '"P{rparenlend}"'
   asciimath:
-  - __{rparenlend}
+  - '"P{rparenlend}"'
   mathml:
   - "&#x23a0;"
   latex:
@@ -13306,9 +13330,9 @@
   html:
   - "&#x23a0;"
 - unicodemath:
-  - __{Rparenless}
+  - '"P{Rparenless}"'
   asciimath:
-  - __{Rparenless}
+  - '"P{Rparenless}"'
   mathml:
   - "&#x2996;"
   latex:
@@ -13318,9 +13342,9 @@
   html:
   - "&#x2996;"
 - unicodemath:
-  - __{rparenuend}
+  - '"P{rparenuend}"'
   asciimath:
-  - __{rparenuend}
+  - '"P{rparenuend}"'
   mathml:
   - "&#x239e;"
   latex:
@@ -13330,9 +13354,9 @@
   html:
   - "&#x239e;"
 - unicodemath:
-  - __{rppolint}
+  - '"P{rppolint}"'
   asciimath:
-  - __{rppolint}
+  - '"P{rppolint}"'
   mathml:
   - "&#x2a12;"
   latex:
@@ -13342,9 +13366,9 @@
   html:
   - "&#x2a12;"
 - unicodemath:
-  - __{RR}
+  - '"P{RR}"'
   asciimath:
-  - __{RR}
+  - '"P{RR}"'
   mathml:
   - "&#x211d;"
   latex:
@@ -13354,9 +13378,9 @@
   html:
   - "&#x211d;"
 - unicodemath:
-  - __{RRightarrow}
+  - '"P{RRightarrow}"'
   asciimath:
-  - __{RRightarrow}
+  - '"P{RRightarrow}"'
   mathml:
   - "&#x2b46;"
   latex:
@@ -13366,9 +13390,9 @@
   html:
   - "&#x2b46;"
 - unicodemath:
-  - __{Rsh}
+  - '"P{Rsh}"'
   asciimath:
-  - __{Rsh}
+  - '"P{Rsh}"'
   mathml:
   - "&#x21b1;"
   latex:
@@ -13378,9 +13402,9 @@
   html:
   - "&#x21b1;"
 - unicodemath:
-  - __{rsolbar}
+  - '"P{rsolbar}"'
   asciimath:
-  - __{rsolbar}
+  - '"P{rsolbar}"'
   mathml:
   - "&#x29f7;"
   latex:
@@ -13390,9 +13414,9 @@
   html:
   - "&#x29f7;"
 - unicodemath:
-  - __{rsqhook}
+  - '"P{rsqhook}"'
   asciimath:
-  - __{rsqhook}
+  - '"P{rsqhook}"'
   mathml:
   - "&#x2ace;"
   latex:
@@ -13402,11 +13426,11 @@
   html:
   - "&#x2ace;"
 - unicodemath:
-  - __{nrres}
-  - __{rsub}
+  - '"P{nrres}"'
+  - '"P{rsub}"'
   asciimath:
-  - __{nrres}
-  - __{rsub}
+  - '"P{nrres}"'
+  - '"P{rsub}"'
   mathml:
   - "&#x2a65;"
   latex:
@@ -13418,7 +13442,7 @@
   - "&#x2a65;"
 - unicodemath:
   - rtimes
-  - __{><|}
+  - '"P{><|}"'
   asciimath:
   - rtimes
   - "><|"
@@ -13426,15 +13450,15 @@
   - "&#x22ca;"
   latex:
   - rtimes
-  - __{><|}
+  - "\\text{P[><|]}"
   omml:
   - "&#x22ca;"
   html:
   - "&#x22ca;"
 - unicodemath:
-  - __{rtriltri}
+  - '"P{rtriltri}"'
   asciimath:
-  - __{rtriltri}
+  - '"P{rtriltri}"'
   mathml:
   - "&#x29ce;"
   latex:
@@ -13444,9 +13468,9 @@
   html:
   - "&#x29ce;"
 - unicodemath:
-  - __{ruledelayed}
+  - '"P{ruledelayed}"'
   asciimath:
-  - __{ruledelayed}
+  - '"P{ruledelayed}"'
   mathml:
   - "&#x29f4;"
   latex:
@@ -13456,9 +13480,9 @@
   html:
   - "&#x29f4;"
 - unicodemath:
-  - __{rvboxline}
+  - '"P{rvboxline}"'
   asciimath:
-  - __{rvboxline}
+  - '"P{rvboxline}"'
   mathml:
   - "&#x23b9;"
   latex:
@@ -13468,13 +13492,13 @@
   html:
   - "&#x23b9;"
 - unicodemath:
-  - __{parallel}
-  - __{lVert}
-  - __{rVert}
+  - '"P{parallel}"'
+  - '"P{lVert}"'
+  - '"P{rVert}"'
   asciimath:
-  - __{parallel}
-  - __{lVert}
-  - __{rVert}
+  - '"P{parallel}"'
+  - '"P{lVert}"'
+  - '"P{rVert}"'
   mathml:
   - "&#x2225;"
   latex:
@@ -13486,9 +13510,9 @@
   html:
   - "&#x2225;"
 - unicodemath:
-  - __{Rvzigzag}
+  - '"P{Rvzigzag}"'
   asciimath:
-  - __{Rvzigzag}
+  - '"P{Rvzigzag}"'
   mathml:
   - "&#x29db;"
   latex:
@@ -13498,11 +13522,11 @@
   html:
   - "&#x29db;"
 - unicodemath:
-  - __{frownie}
-  - __{sadface}
+  - '"P{frownie}"'
+  - '"P{sadface}"'
   asciimath:
-  - __{frownie}
-  - __{sadface}
+  - '"P{frownie}"'
+  - '"P{sadface}"'
   mathml:
   - "&#x2639;"
   latex:
@@ -13513,9 +13537,9 @@
   html:
   - "&#x2639;"
 - unicodemath:
-  - __{sagittarius}
+  - '"P{sagittarius}"'
   asciimath:
-  - __{sagittarius}
+  - '"P{sagittarius}"'
   mathml:
   - "&#x2650;"
   latex:
@@ -13525,11 +13549,11 @@
   html:
   - "&#x2650;"
 - unicodemath:
-  - __{eqeqeq}
-  - __{Same}
+  - '"P{eqeqeq}"'
+  - '"P{Same}"'
   asciimath:
-  - __{eqeqeq}
-  - __{Same}
+  - '"P{eqeqeq}"'
+  - '"P{Same}"'
   mathml:
   - "&#x2a76;"
   latex:
@@ -13540,11 +13564,11 @@
   html:
   - "&#x2a76;"
 - unicodemath:
-  - __{upsampi}
-  - __{sampi}
+  - '"P{upsampi}"'
+  - '"P{sampi}"'
   asciimath:
-  - __{upsampi}
-  - __{sampi}
+  - '"P{upsampi}"'
+  - '"P{sampi}"'
   mathml:
   - "&#x3e1;"
   latex:
@@ -13555,9 +13579,9 @@
   html:
   - "&#x3e1;"
 - unicodemath:
-  - __{sansLmirrored}
+  - '"P{sansLmirrored}"'
   asciimath:
-  - __{sansLmirrored}
+  - '"P{sansLmirrored}"'
   mathml:
   - "&#x2143;"
   latex:
@@ -13567,9 +13591,9 @@
   html:
   - "&#x2143;"
 - unicodemath:
-  - __{sansLturned}
+  - '"P{sansLturned}"'
   asciimath:
-  - __{sansLturned}
+  - '"P{sansLturned}"'
   mathml:
   - "&#x2142;"
   latex:
@@ -13579,11 +13603,11 @@
   html:
   - "&#x2142;"
 - unicodemath:
-  - __{saturn}
-  - __{Saturn}
+  - '"P{saturn}"'
+  - '"P{Saturn}"'
   asciimath:
-  - __{saturn}
-  - __{Saturn}
+  - '"P{saturn}"'
+  - '"P{Saturn}"'
   mathml:
   - "&#x2644;"
   latex:
@@ -13594,11 +13618,11 @@
   html:
   - "&#x2644;"
 - unicodemath:
-  - __{scorpio}
-  - __{Scorpio}
+  - '"P{scorpio}"'
+  - '"P{Scorpio}"'
   asciimath:
-  - __{scorpio}
-  - __{Scorpio}
+  - '"P{scorpio}"'
+  - '"P{Scorpio}"'
   mathml:
   - "&#x264f;"
   latex:
@@ -13609,9 +13633,9 @@
   html:
   - "&#x264f;"
 - unicodemath:
-  - __{scpolint}
+  - '"P{scpolint}"'
   asciimath:
-  - __{scpolint}
+  - '"P{scpolint}"'
   mathml:
   - "&#x2a13;"
   latex:
@@ -13621,9 +13645,9 @@
   html:
   - "&#x2a13;"
 - unicodemath:
-  - __{scurel}
+  - '"P{scurel}"'
   asciimath:
-  - __{scurel}
+  - '"P{scurel}"'
   mathml:
   - "&#x22b1;"
   latex:
@@ -13633,13 +13657,13 @@
   html:
   - "&#x22b1;"
 - unicodemath:
-  - __{corresponds}
-  - __{wedgeq}
-  - __{sdef}
+  - '"P{corresponds}"'
+  - '"P{wedgeq}"'
+  - '"P{sdef}"'
   asciimath:
-  - __{corresponds}
-  - __{wedgeq}
-  - __{sdef}
+  - '"P{corresponds}"'
+  - '"P{wedgeq}"'
+  - '"P{sdef}"'
   mathml:
   - "&#x2259;"
   latex:
@@ -13651,9 +13675,9 @@
   html:
   - "&#x2259;"
 - unicodemath:
-  - __{Searrow}
+  - '"P{Searrow}"'
   asciimath:
-  - __{Searrow}
+  - '"P{Searrow}"'
   mathml:
   - "&#x21d8;"
   latex:
@@ -13663,29 +13687,29 @@
   html:
   - "&#x21d8;"
 - unicodemath:
-  - __{''}
-  - __{second}
-  - __{dprime}
+  - '"P{''''}"'
+  - '"P{second}"'
+  - '"P{dprime}"'
   asciimath:
   - "''"
-  - __{second}
-  - __{dprime}
+  - '"P{second}"'
+  - '"P{dprime}"'
   mathml:
   - "&#x2033;"
   latex:
   - second
   - dprime
-  - __{''}
+  - "\\text{P['']}"
   omml:
   - "&#x2033;"
   html:
   - "&#x2033;"
 - unicodemath:
-  - __{zcmp}
-  - __{semi}
+  - '"P{zcmp}"'
+  - '"P{semi}"'
   asciimath:
-  - __{zcmp}
-  - __{semi}
+  - '"P{zcmp}"'
+  - '"P{semi}"'
   mathml:
   - "&#x2a1f;"
   latex:
@@ -13696,11 +13720,11 @@
   html:
   - "&#x2a1f;"
 - unicodemath:
-  - __{;}
-  - __{semicolon}
+  - '"P{;}"'
+  - '"P{semicolon}"'
   asciimath:
   - ";"
-  - __{semicolon}
+  - '"P{semicolon}"'
   mathml:
   - "&#x3b;"
   latex:
@@ -13711,9 +13735,9 @@
   html:
   - "&#x3b;"
 - unicodemath:
-  - __{seovnearrow}
+  - '"P{seovnearrow}"'
   asciimath:
-  - __{seovnearrow}
+  - '"P{seovnearrow}"'
   mathml:
   - "&#x292d;"
   latex:
@@ -13724,23 +13748,23 @@
   - "&#x292d;"
 - unicodemath:
   - setminus
-  - __{smallsetminus}
+  - '"P{smallsetminus}"'
   asciimath:
-  - __{setminus}
-  - __{smallsetminus}
+  - '"P{setminus}"'
+  - '"P{smallsetminus}"'
   mathml:
   - "&#x2216;"
   latex:
   - smallsetminus
-  - __{setminus}
+  - "\\text{P[setminus]}"
   omml:
   - "&#x2216;"
   html:
   - "&#x2216;"
 - unicodemath:
-  - __{sharp}
+  - '"P{sharp}"'
   asciimath:
-  - __{sharp}
+  - '"P{sharp}"'
   mathml:
   - "&#x266f;"
   latex:
@@ -13750,9 +13774,9 @@
   html:
   - "&#x266f;"
 - unicodemath:
-  - __{shortdowntack}
+  - '"P{shortdowntack}"'
   asciimath:
-  - __{shortdowntack}
+  - '"P{shortdowntack}"'
   mathml:
   - "&#x2adf;"
   latex:
@@ -13762,9 +13786,9 @@
   html:
   - "&#x2adf;"
 - unicodemath:
-  - __{shortlefttack}
+  - '"P{shortlefttack}"'
   asciimath:
-  - __{shortlefttack}
+  - '"P{shortlefttack}"'
   mathml:
   - "&#x2ade;"
   latex:
@@ -13774,9 +13798,9 @@
   html:
   - "&#x2ade;"
 - unicodemath:
-  - __{shortrightarrowleftarrow}
+  - '"P{shortrightarrowleftarrow}"'
   asciimath:
-  - __{shortrightarrowleftarrow}
+  - '"P{shortrightarrowleftarrow}"'
   mathml:
   - "&#x2944;"
   latex:
@@ -13786,9 +13810,9 @@
   html:
   - "&#x2944;"
 - unicodemath:
-  - __{shortuptack}
+  - '"P{shortuptack}"'
   asciimath:
-  - __{shortuptack}
+  - '"P{shortuptack}"'
   mathml:
   - "&#x2ae0;"
   latex:
@@ -13798,9 +13822,9 @@
   html:
   - "&#x2ae0;"
 - unicodemath:
-  - __{shuffle}
+  - '"P{shuffle}"'
   asciimath:
-  - __{shuffle}
+  - '"P{shuffle}"'
   mathml:
   - "&#x29e2;"
   latex:
@@ -13811,10 +13835,10 @@
   - "&#x29e2;"
 - unicodemath:
   - sigma
-  - __{upsigma}
+  - '"P{upsigma}"'
   asciimath:
   - sigma
-  - __{upsigma}
+  - '"P{upsigma}"'
   mathml:
   - "&#x3c3;"
   latex:
@@ -13827,7 +13851,7 @@
 - unicodemath:
   - sim
   asciimath:
-  - __{sim}
+  - '"P{sim}"'
   mathml:
   - "&#x223c;"
   latex:
@@ -13839,7 +13863,7 @@
 - unicodemath:
   - simeq
   asciimath:
-  - __{simeq}
+  - '"P{simeq}"'
   mathml:
   - "&#x2243;"
   latex:
@@ -13849,9 +13873,9 @@
   html:
   - "&#x2243;"
 - unicodemath:
-  - __{simgE}
+  - '"P{simgE}"'
   asciimath:
-  - __{simgE}
+  - '"P{simgE}"'
   mathml:
   - "&#x2aa0;"
   latex:
@@ -13861,9 +13885,9 @@
   html:
   - "&#x2aa0;"
 - unicodemath:
-  - __{simgtr}
+  - '"P{simgtr}"'
   asciimath:
-  - __{simgtr}
+  - '"P{simgtr}"'
   mathml:
   - "&#x2a9e;"
   latex:
@@ -13873,9 +13897,9 @@
   html:
   - "&#x2a9e;"
 - unicodemath:
-  - __{similarleftarrow}
+  - '"P{similarleftarrow}"'
   asciimath:
-  - __{similarleftarrow}
+  - '"P{similarleftarrow}"'
   mathml:
   - "&#x2b49;"
   latex:
@@ -13885,9 +13909,9 @@
   html:
   - "&#x2b49;"
 - unicodemath:
-  - __{similarrightarrow}
+  - '"P{similarrightarrow}"'
   asciimath:
-  - __{similarrightarrow}
+  - '"P{similarrightarrow}"'
   mathml:
   - "&#x2972;"
   latex:
@@ -13897,9 +13921,9 @@
   html:
   - "&#x2972;"
 - unicodemath:
-  - __{simlE}
+  - '"P{simlE}"'
   asciimath:
-  - __{simlE}
+  - '"P{simlE}"'
   mathml:
   - "&#x2a9f;"
   latex:
@@ -13909,9 +13933,9 @@
   html:
   - "&#x2a9f;"
 - unicodemath:
-  - __{simless}
+  - '"P{simless}"'
   asciimath:
-  - __{simless}
+  - '"P{simless}"'
   mathml:
   - "&#x2a9d;"
   latex:
@@ -13921,9 +13945,9 @@
   html:
   - "&#x2a9d;"
 - unicodemath:
-  - __{simminussim}
+  - '"P{simminussim}"'
   asciimath:
-  - __{simminussim}
+  - '"P{simminussim}"'
   mathml:
   - "&#x2a6c;"
   latex:
@@ -13933,9 +13957,9 @@
   html:
   - "&#x2a6c;"
 - unicodemath:
-  - __{simneqq}
+  - '"P{simneqq}"'
   asciimath:
-  - __{simneqq}
+  - '"P{simneqq}"'
   mathml:
   - "&#x2246;"
   latex:
@@ -13945,9 +13969,9 @@
   html:
   - "&#x2246;"
 - unicodemath:
-  - __{simplus}
+  - '"P{simplus}"'
   asciimath:
-  - __{simplus}
+  - '"P{simplus}"'
   mathml:
   - "&#x2a24;"
   latex:
@@ -13957,9 +13981,9 @@
   html:
   - "&#x2a24;"
 - unicodemath:
-  - __{simrdots}
+  - '"P{simrdots}"'
   asciimath:
-  - __{simrdots}
+  - '"P{simrdots}"'
   mathml:
   - "&#x2a6b;"
   latex:
@@ -13969,9 +13993,9 @@
   html:
   - "&#x2a6b;"
 - unicodemath:
-  - __{sixteenthnote}
+  - '"P{sixteenthnote}"'
   asciimath:
-  - __{sixteenthnote}
+  - '"P{sixteenthnote}"'
   mathml:
   - "&#x266c;"
   latex:
@@ -13981,9 +14005,9 @@
   html:
   - "&#x266c;"
 - unicodemath:
-  - __{skull}
+  - '"P{skull}"'
   asciimath:
-  - __{skull}
+  - '"P{skull}"'
   mathml:
   - "&#x2620;"
   latex:
@@ -13994,12 +14018,12 @@
   - "&#x2620;"
 - unicodemath:
   - "/"
-  - __{divslash}
-  - __{slash}
+  - '"P{divslash}"'
+  - '"P{slash}"'
   asciimath:
   - "//"
-  - __{divslash}
-  - __{slash}
+  - '"P{divslash}"'
+  - '"P{slash}"'
   mathml:
   - "&#x2215;"
   latex:
@@ -14011,9 +14035,9 @@
   html:
   - "&#x2215;"
 - unicodemath:
-  - __{smallblacktriangleleft}
+  - '"P{smallblacktriangleleft}"'
   asciimath:
-  - __{smallblacktriangleleft}
+  - '"P{smallblacktriangleleft}"'
   mathml:
   - "&#x25c2;"
   latex:
@@ -14023,9 +14047,9 @@
   html:
   - "&#x25c2;"
 - unicodemath:
-  - __{smallblacktriangleright}
+  - '"P{smallblacktriangleright}"'
   asciimath:
-  - __{smallblacktriangleright}
+  - '"P{smallblacktriangleright}"'
   mathml:
   - "&#x25b8;"
   latex:
@@ -14035,9 +14059,9 @@
   html:
   - "&#x25b8;"
 - unicodemath:
-  - __{smallin}
+  - '"P{smallin}"'
   asciimath:
-  - __{smallin}
+  - '"P{smallin}"'
   mathml:
   - "&#x220a;"
   latex:
@@ -14047,9 +14071,9 @@
   html:
   - "&#x220a;"
 - unicodemath:
-  - __{smallni}
+  - '"P{smallni}"'
   asciimath:
-  - __{smallni}
+  - '"P{smallni}"'
   mathml:
   - "&#x220d;"
   latex:
@@ -14059,9 +14083,9 @@
   html:
   - "&#x220d;"
 - unicodemath:
-  - __{smalltriangleleft}
+  - '"P{smalltriangleleft}"'
   asciimath:
-  - __{smalltriangleleft}
+  - '"P{smalltriangleleft}"'
   mathml:
   - "&#x25c3;"
   latex:
@@ -14071,9 +14095,9 @@
   html:
   - "&#x25c3;"
 - unicodemath:
-  - __{smalltriangleright}
+  - '"P{smalltriangleright}"'
   asciimath:
-  - __{smalltriangleright}
+  - '"P{smalltriangleright}"'
   mathml:
   - "&#x25b9;"
   latex:
@@ -14083,9 +14107,9 @@
   html:
   - "&#x25b9;"
 - unicodemath:
-  - __{smashtimes}
+  - '"P{smashtimes}"'
   asciimath:
-  - __{smashtimes}
+  - '"P{smashtimes}"'
   mathml:
   - "&#x2a33;"
   latex:
@@ -14095,11 +14119,11 @@
   html:
   - "&#x2a33;"
 - unicodemath:
-  - __{smblkcircle}
-  - __{bullet}
+  - '"P{smblkcircle}"'
+  - '"P{bullet}"'
   asciimath:
-  - __{smblkcircle}
-  - __{bullet}
+  - '"P{smblkcircle}"'
+  - '"P{bullet}"'
   mathml:
   - "&#x2022;"
   latex:
@@ -14110,9 +14134,9 @@
   html:
   - "&#x2022;"
 - unicodemath:
-  - __{smblkdiamond}
+  - '"P{smblkdiamond}"'
   asciimath:
-  - __{smblkdiamond}
+  - '"P{smblkdiamond}"'
   mathml:
   - "&#x2b29;"
   latex:
@@ -14122,9 +14146,9 @@
   html:
   - "&#x2b29;"
 - unicodemath:
-  - __{smblklozenge}
+  - '"P{smblklozenge}"'
   asciimath:
-  - __{smblklozenge}
+  - '"P{smblklozenge}"'
   mathml:
   - "&#x2b2a;"
   latex:
@@ -14134,9 +14158,9 @@
   html:
   - "&#x2b2a;"
 - unicodemath:
-  - __{smblksquare}
+  - '"P{smblksquare}"'
   asciimath:
-  - __{smblksquare}
+  - '"P{smblksquare}"'
   mathml:
   - "&#x25aa;"
   latex:
@@ -14146,9 +14170,9 @@
   html:
   - "&#x25aa;"
 - unicodemath:
-  - __{smeparsl}
+  - '"P{smeparsl}"'
   asciimath:
-  - __{smeparsl}
+  - '"P{smeparsl}"'
   mathml:
   - "&#x29e4;"
   latex:
@@ -14158,9 +14182,9 @@
   html:
   - "&#x29e4;"
 - unicodemath:
-  - __{smile}
+  - '"P{smile}"'
   asciimath:
-  - __{smile}
+  - '"P{smile}"'
   mathml:
   - "&#x2323;"
   latex:
@@ -14170,11 +14194,11 @@
   html:
   - "&#x2323;"
 - unicodemath:
-  - __{smileface}
-  - __{smiley}
+  - '"P{smileface}"'
+  - '"P{smiley}"'
   asciimath:
-  - __{smileface}
-  - __{smiley}
+  - '"P{smileface}"'
+  - '"P{smiley}"'
   mathml:
   - "&#x263a;"
   latex:
@@ -14185,9 +14209,9 @@
   html:
   - "&#x263a;"
 - unicodemath:
-  - __{smt}
+  - '"P{smt}"'
   asciimath:
-  - __{smt}
+  - '"P{smt}"'
   mathml:
   - "&#x2aaa;"
   latex:
@@ -14197,9 +14221,9 @@
   html:
   - "&#x2aaa;"
 - unicodemath:
-  - __{smte}
+  - '"P{smte}"'
   asciimath:
-  - __{smte}
+  - '"P{smte}"'
   mathml:
   - "&#x2aac;"
   latex:
@@ -14209,9 +14233,9 @@
   html:
   - "&#x2aac;"
 - unicodemath:
-  - __{smwhitestar}
+  - '"P{smwhitestar}"'
   asciimath:
-  - __{smwhitestar}
+  - '"P{smwhitestar}"'
   mathml:
   - "&#x2b52;"
   latex:
@@ -14221,9 +14245,9 @@
   html:
   - "&#x2b52;"
 - unicodemath:
-  - __{smwhtcircle}
+  - '"P{smwhtcircle}"'
   asciimath:
-  - __{smwhtcircle}
+  - '"P{smwhtcircle}"'
   mathml:
   - "&#x25e6;"
   latex:
@@ -14233,9 +14257,9 @@
   html:
   - "&#x25e6;"
 - unicodemath:
-  - __{smwhtlozenge}
+  - '"P{smwhtlozenge}"'
   asciimath:
-  - __{smwhtlozenge}
+  - '"P{smwhtlozenge}"'
   mathml:
   - "&#x2b2b;"
   latex:
@@ -14245,9 +14269,9 @@
   html:
   - "&#x2b2b;"
 - unicodemath:
-  - __{smwhtsquare}
+  - '"P{smwhtsquare}"'
   asciimath:
-  - __{smwhtsquare}
+  - '"P{smwhtsquare}"'
   mathml:
   - "&#x25ab;"
   latex:
@@ -14257,13 +14281,13 @@
   html:
   - "&#x25ab;"
 - unicodemath:
-  - __{\ }
+  - '"P{\ }"'
   asciimath:
   - "\\ "
   mathml:
   - "&#xa0;"
   latex:
-  - __{\ }
+  - "\\text{P[\\ ]}"
   omml:
   - "&#xa0;"
   html:
@@ -14271,7 +14295,7 @@
 - unicodemath:
   - spadesuit
   asciimath:
-  - __{spadesuit}
+  - '"P{spadesuit}"'
   mathml:
   - "&#x2660;"
   latex:
@@ -14281,9 +14305,9 @@
   html:
   - "&#x2660;"
 - unicodemath:
-  - __{spddot}
+  - '"P{spddot}"'
   asciimath:
-  - __{spddot}
+  - '"P{spddot}"'
   mathml:
   - "&#xa8;"
   latex:
@@ -14293,9 +14317,9 @@
   html:
   - "&#xa8;"
 - unicodemath:
-  - __{sphat}
+  - '"P{sphat}"'
   asciimath:
-  - __{sphat}
+  - '"P{sphat}"'
   mathml:
   - "&#x5e;"
   latex:
@@ -14305,9 +14329,9 @@
   html:
   - "&#x5e;"
 - unicodemath:
-  - __{sphericalangleup}
+  - '"P{sphericalangleup}"'
   asciimath:
-  - __{sphericalangleup}
+  - '"P{sphericalangleup}"'
   mathml:
   - "&#x29a1;"
   latex:
@@ -14317,11 +14341,11 @@
   html:
   - "&#x29a1;"
 - unicodemath:
-  - __{mdsmblkcircle}
-  - __{spot}
+  - '"P{mdsmblkcircle}"'
+  - '"P{spot}"'
   asciimath:
-  - __{mdsmblkcircle}
-  - __{spot}
+  - '"P{mdsmblkcircle}"'
+  - '"P{spot}"'
   mathml:
   - "&#x2981;"
   latex:
@@ -14344,24 +14368,24 @@
   html:
   - "&#x27;"
 - unicodemath:
-  - __{~}
-  - __{sptilde}
+  - '"P{~}"'
+  - '"P{sptilde}"'
   asciimath:
   - "~"
-  - __{sptilde}
+  - '"P{sptilde}"'
   mathml:
   - "&#x7e;"
   latex:
   - sptilde
-  - __{~}
+  - "\\text{P[~]}"
   omml:
   - "&#x7e;"
   html:
   - "&#x7e;"
 - unicodemath:
-  - __{Sqcap}
+  - '"P{Sqcap}"'
   asciimath:
-  - __{Sqcap}
+  - '"P{Sqcap}"'
   mathml:
   - "&#x2a4e;"
   latex:
@@ -14371,9 +14395,9 @@
   html:
   - "&#x2a4e;"
 - unicodemath:
-  - __{Sqcup}
+  - '"P{Sqcup}"'
   asciimath:
-  - __{Sqcup}
+  - '"P{Sqcup}"'
   mathml:
   - "&#x2a4f;"
   latex:
@@ -14383,11 +14407,11 @@
   html:
   - "&#x2a4f;"
 - unicodemath:
-  - __{sqrint}
-  - __{sqint}
+  - '"P{sqrint}"'
+  - '"P{sqint}"'
   asciimath:
-  - __{sqrint}
-  - __{sqint}
+  - '"P{sqrint}"'
+  - '"P{sqint}"'
   mathml:
   - "&#x2a16;"
   latex:
@@ -14398,11 +14422,11 @@
   html:
   - "&#x2a16;"
 - unicodemath:
-  - __{wasylozenge}
-  - __{sqlozenge}
+  - '"P{wasylozenge}"'
+  - '"P{sqlozenge}"'
   asciimath:
-  - __{wasylozenge}
-  - __{sqlozenge}
+  - '"P{wasylozenge}"'
+  - '"P{sqlozenge}"'
   mathml:
   - "&#x2311;"
   latex:
@@ -14413,9 +14437,9 @@
   html:
   - "&#x2311;"
 - unicodemath:
-  - __{sqrtbottom}
+  - '"P{sqrtbottom}"'
   asciimath:
-  - __{sqrtbottom}
+  - '"P{sqrtbottom}"'
   mathml:
   - "&#x23b7;"
   latex:
@@ -14427,7 +14451,7 @@
 - unicodemath:
   - sqsubset
   asciimath:
-  - __{sqsubset}
+  - '"P{sqsubset}"'
   mathml:
   - "&#x228f;"
   latex:
@@ -14439,7 +14463,7 @@
 - unicodemath:
   - sqsubseteq
   asciimath:
-  - __{sqsubseteq}
+  - '"P{sqsubseteq}"'
   mathml:
   - "&#x2291;"
   latex:
@@ -14449,9 +14473,9 @@
   html:
   - "&#x2291;"
 - unicodemath:
-  - __{sqsubsetneq}
+  - '"P{sqsubsetneq}"'
   asciimath:
-  - __{sqsubsetneq}
+  - '"P{sqsubsetneq}"'
   mathml:
   - "&#x22e4;"
   latex:
@@ -14463,7 +14487,7 @@
 - unicodemath:
   - sqsupset
   asciimath:
-  - __{sqsupset}
+  - '"P{sqsupset}"'
   mathml:
   - "&#x2290;"
   latex:
@@ -14475,7 +14499,7 @@
 - unicodemath:
   - sqsupseteq
   asciimath:
-  - __{sqsupseteq}
+  - '"P{sqsupseteq}"'
   mathml:
   - "&#x2292;"
   latex:
@@ -14485,9 +14509,9 @@
   html:
   - "&#x2292;"
 - unicodemath:
-  - __{Square}
+  - '"P{Square}"'
   asciimath:
-  - __{Square}
+  - '"P{Square}"'
   mathml:
   - "&#x2610;"
   latex:
@@ -14497,9 +14521,9 @@
   html:
   - "&#x2610;"
 - unicodemath:
-  - __{squarebotblack}
+  - '"P{squarebotblack}"'
   asciimath:
-  - __{squarebotblack}
+  - '"P{squarebotblack}"'
   mathml:
   - "&#x2b13;"
   latex:
@@ -14509,9 +14533,9 @@
   html:
   - "&#x2b13;"
 - unicodemath:
-  - __{squarecrossfill}
+  - '"P{squarecrossfill}"'
   asciimath:
-  - __{squarecrossfill}
+  - '"P{squarecrossfill}"'
   mathml:
   - "&#x25a9;"
   latex:
@@ -14521,9 +14545,9 @@
   html:
   - "&#x25a9;"
 - unicodemath:
-  - __{squarehfill}
+  - '"P{squarehfill}"'
   asciimath:
-  - __{squarehfill}
+  - '"P{squarehfill}"'
   mathml:
   - "&#x25a4;"
   latex:
@@ -14533,9 +14557,9 @@
   html:
   - "&#x25a4;"
 - unicodemath:
-  - __{squarehvfill}
+  - '"P{squarehvfill}"'
   asciimath:
-  - __{squarehvfill}
+  - '"P{squarehvfill}"'
   mathml:
   - "&#x25a6;"
   latex:
@@ -14545,9 +14569,9 @@
   html:
   - "&#x25a6;"
 - unicodemath:
-  - __{squareleftblack}
+  - '"P{squareleftblack}"'
   asciimath:
-  - __{squareleftblack}
+  - '"P{squareleftblack}"'
   mathml:
   - "&#x25e7;"
   latex:
@@ -14557,9 +14581,9 @@
   html:
   - "&#x25e7;"
 - unicodemath:
-  - __{squarellblack}
+  - '"P{squarellblack}"'
   asciimath:
-  - __{squarellblack}
+  - '"P{squarellblack}"'
   mathml:
   - "&#x2b15;"
   latex:
@@ -14569,9 +14593,9 @@
   html:
   - "&#x2b15;"
 - unicodemath:
-  - __{squarellquad}
+  - '"P{squarellquad}"'
   asciimath:
-  - __{squarellquad}
+  - '"P{squarellquad}"'
   mathml:
   - "&#x25f1;"
   latex:
@@ -14581,9 +14605,9 @@
   html:
   - "&#x25f1;"
 - unicodemath:
-  - __{squarelrblack}
+  - '"P{squarelrblack}"'
   asciimath:
-  - __{squarelrblack}
+  - '"P{squarelrblack}"'
   mathml:
   - "&#x25ea;"
   latex:
@@ -14593,9 +14617,9 @@
   html:
   - "&#x25ea;"
 - unicodemath:
-  - __{squarelrquad}
+  - '"P{squarelrquad}"'
   asciimath:
-  - __{squarelrquad}
+  - '"P{squarelrquad}"'
   mathml:
   - "&#x25f2;"
   latex:
@@ -14605,9 +14629,9 @@
   html:
   - "&#x25f2;"
 - unicodemath:
-  - __{squareneswfill}
+  - '"P{squareneswfill}"'
   asciimath:
-  - __{squareneswfill}
+  - '"P{squareneswfill}"'
   mathml:
   - "&#x25a8;"
   latex:
@@ -14617,9 +14641,9 @@
   html:
   - "&#x25a8;"
 - unicodemath:
-  - __{squarenwsefill}
+  - '"P{squarenwsefill}"'
   asciimath:
-  - __{squarenwsefill}
+  - '"P{squarenwsefill}"'
   mathml:
   - "&#x25a7;"
   latex:
@@ -14629,9 +14653,9 @@
   html:
   - "&#x25a7;"
 - unicodemath:
-  - __{squarerightblack}
+  - '"P{squarerightblack}"'
   asciimath:
-  - __{squarerightblack}
+  - '"P{squarerightblack}"'
   mathml:
   - "&#x25e8;"
   latex:
@@ -14641,9 +14665,9 @@
   html:
   - "&#x25e8;"
 - unicodemath:
-  - __{squaretopblack}
+  - '"P{squaretopblack}"'
   asciimath:
-  - __{squaretopblack}
+  - '"P{squaretopblack}"'
   mathml:
   - "&#x2b12;"
   latex:
@@ -14653,9 +14677,9 @@
   html:
   - "&#x2b12;"
 - unicodemath:
-  - __{squareulblack}
+  - '"P{squareulblack}"'
   asciimath:
-  - __{squareulblack}
+  - '"P{squareulblack}"'
   mathml:
   - "&#x25e9;"
   latex:
@@ -14665,9 +14689,9 @@
   html:
   - "&#x25e9;"
 - unicodemath:
-  - __{squareulquad}
+  - '"P{squareulquad}"'
   asciimath:
-  - __{squareulquad}
+  - '"P{squareulquad}"'
   mathml:
   - "&#x25f0;"
   latex:
@@ -14677,9 +14701,9 @@
   html:
   - "&#x25f0;"
 - unicodemath:
-  - __{squareurblack}
+  - '"P{squareurblack}"'
   asciimath:
-  - __{squareurblack}
+  - '"P{squareurblack}"'
   mathml:
   - "&#x2b14;"
   latex:
@@ -14689,9 +14713,9 @@
   html:
   - "&#x2b14;"
 - unicodemath:
-  - __{squareurquad}
+  - '"P{squareurquad}"'
   asciimath:
-  - __{squareurquad}
+  - '"P{squareurquad}"'
   mathml:
   - "&#x25f3;"
   latex:
@@ -14701,9 +14725,9 @@
   html:
   - "&#x25f3;"
 - unicodemath:
-  - __{squarevfill}
+  - '"P{squarevfill}"'
   asciimath:
-  - __{squarevfill}
+  - '"P{squarevfill}"'
   mathml:
   - "&#x25a5;"
   latex:
@@ -14713,9 +14737,9 @@
   html:
   - "&#x25a5;"
 - unicodemath:
-  - __{squoval}
+  - '"P{squoval}"'
   asciimath:
-  - __{squoval}
+  - '"P{squoval}"'
   mathml:
   - "&#x25a2;"
   latex:
@@ -14725,9 +14749,9 @@
   html:
   - "&#x25a2;"
 - unicodemath:
-  - __{sslash}
+  - '"P{sslash}"'
   asciimath:
-  - __{sslash}
+  - '"P{sslash}"'
   mathml:
   - "&#x2afd;"
   latex:
@@ -14738,7 +14762,7 @@
   - "&#x2afd;"
 - unicodemath:
   - star
-  - __{***}
+  - '"P{***}"'
   asciimath:
   - "***"
   - star
@@ -14746,15 +14770,15 @@
   - "&#x22c6;"
   latex:
   - star
-  - __{***}
+  - "\\text{P[***]}"
   omml:
   - "&#x22c6;"
   html:
   - "&#x22c6;"
 - unicodemath:
-  - __{stareq}
+  - '"P{stareq}"'
   asciimath:
-  - __{stareq}
+  - '"P{stareq}"'
   mathml:
   - "&#x225b;"
   latex:
@@ -14764,9 +14788,9 @@
   html:
   - "&#x225b;"
 - unicodemath:
-  - __{steaming}
+  - '"P{steaming}"'
   asciimath:
-  - __{steaming}
+  - '"P{steaming}"'
   mathml:
   - "&#x2615;"
   latex:
@@ -14776,11 +14800,11 @@
   html:
   - "&#x2615;"
 - unicodemath:
-  - __{upstigma}
-  - __{stigma}
+  - '"P{upstigma}"'
+  - '"P{stigma}"'
   asciimath:
-  - __{upstigma}
-  - __{stigma}
+  - '"P{upstigma}"'
+  - '"P{stigma}"'
   mathml:
   - "&#x3db;"
   latex:
@@ -14791,11 +14815,11 @@
   html:
   - "&#x3db;"
 - unicodemath:
-  - __{leftfishtail}
-  - __{strictfi}
+  - '"P{leftfishtail}"'
+  - '"P{strictfi}"'
   asciimath:
-  - __{leftfishtail}
-  - __{strictfi}
+  - '"P{leftfishtail}"'
+  - '"P{strictfi}"'
   mathml:
   - "&#x297c;"
   latex:
@@ -14806,11 +14830,11 @@
   html:
   - "&#x297c;"
 - unicodemath:
-  - __{rightfishtail}
-  - __{strictif}
+  - '"P{rightfishtail}"'
+  - '"P{strictif}"'
   asciimath:
-  - __{rightfishtail}
-  - __{strictif}
+  - '"P{rightfishtail}"'
+  - '"P{strictif}"'
   mathml:
   - "&#x297d;"
   latex:
@@ -14821,9 +14845,9 @@
   html:
   - "&#x297d;"
 - unicodemath:
-  - __{strns}
+  - '"P{strns}"'
   asciimath:
-  - __{strns}
+  - '"P{strns}"'
   mathml:
   - "&#x23e4;"
   latex:
@@ -14834,7 +14858,7 @@
   - "&#x23e4;"
 - unicodemath:
   - subset
-  - __{sub}
+  - '"P{sub}"'
   asciimath:
   - subset
   - sub
@@ -14842,14 +14866,14 @@
   - "&#x2282;"
   latex:
   - subset
-  - __{sub}
+  - "\\text{P[sub]}"
   omml:
   - "&#x2282;"
   html:
   - "&#x2282;"
 - unicodemath:
-  - __{subseteq}
-  - __{sube}
+  - '"P{subseteq}"'
+  - '"P{sube}"'
   asciimath:
   - subseteq
   - sube
@@ -14857,15 +14881,15 @@
   - "&#x2286;"
   latex:
   - subseteq
-  - __{sube}
+  - "\\text{P[sube]}"
   omml:
   - "&#x2286;"
   html:
   - "&#x2286;"
 - unicodemath:
-  - __{subedot}
+  - '"P{subedot}"'
   asciimath:
-  - __{subedot}
+  - '"P{subedot}"'
   mathml:
   - "&#x2ac3;"
   latex:
@@ -14875,9 +14899,9 @@
   html:
   - "&#x2ac3;"
 - unicodemath:
-  - __{submult}
+  - '"P{submult}"'
   asciimath:
-  - __{submult}
+  - '"P{submult}"'
   mathml:
   - "&#x2ac1;"
   latex:
@@ -14887,9 +14911,9 @@
   html:
   - "&#x2ac1;"
 - unicodemath:
-  - __{subrarr}
+  - '"P{subrarr}"'
   asciimath:
-  - __{subrarr}
+  - '"P{subrarr}"'
   mathml:
   - "&#x2979;"
   latex:
@@ -14901,7 +14925,7 @@
 - unicodemath:
   - Subset
   asciimath:
-  - __{Subset}
+  - '"P{Subset}"'
   mathml:
   - "&#x22d0;"
   latex:
@@ -14911,9 +14935,9 @@
   html:
   - "&#x22d0;"
 - unicodemath:
-  - __{subsetapprox}
+  - '"P{subsetapprox}"'
   asciimath:
-  - __{subsetapprox}
+  - '"P{subsetapprox}"'
   mathml:
   - "&#x2ac9;"
   latex:
@@ -14923,9 +14947,9 @@
   html:
   - "&#x2ac9;"
 - unicodemath:
-  - __{subsetcirc}
+  - '"P{subsetcirc}"'
   asciimath:
-  - __{subsetcirc}
+  - '"P{subsetcirc}"'
   mathml:
   - "&#x27c3;"
   latex:
@@ -14935,9 +14959,9 @@
   html:
   - "&#x27c3;"
 - unicodemath:
-  - __{subsetdot}
+  - '"P{subsetdot}"'
   asciimath:
-  - __{subsetdot}
+  - '"P{subsetdot}"'
   mathml:
   - "&#x2abd;"
   latex:
@@ -14949,25 +14973,25 @@
 - unicodemath:
   - subseteq
   - nsupseteq
-  - __{nsubseteq}
+  - '"P{nsubseteq}"'
   asciimath:
-  - __{subseteq}
-  - __{nsupseteq}
-  - __{nsubseteq}
+  - '"P{subseteq}"'
+  - '"P{nsupseteq}"'
+  - '"P{nsubseteq}"'
   mathml:
   - "&#x2288;"
   latex:
   - nsubseteq
-  - __{subseteq}
-  - __{nsupseteq}
+  - "\\text{P[subseteq]}"
+  - "\\text{P[nsupseteq]}"
   omml:
   - "&#x2288;"
   html:
   - "&#x2288;"
 - unicodemath:
-  - __{subseteqq}
+  - '"P{subseteqq}"'
   asciimath:
-  - __{subseteqq}
+  - '"P{subseteqq}"'
   mathml:
   - "&#x2ac5;"
   latex:
@@ -14978,10 +15002,10 @@
   - "&#x2ac5;"
 - unicodemath:
   - subsetneq
-  - __{varsubsetneq}
+  - '"P{varsubsetneq}"'
   asciimath:
-  - __{subsetneq}
-  - __{varsubsetneq}
+  - '"P{subsetneq}"'
+  - '"P{varsubsetneq}"'
   mathml:
   - "&#x228a;"
   latex:
@@ -14992,9 +15016,9 @@
   html:
   - "&#x228a;"
 - unicodemath:
-  - __{subsetneqq}
+  - '"P{subsetneqq}"'
   asciimath:
-  - __{subsetneqq}
+  - '"P{subsetneqq}"'
   mathml:
   - "&#x2acb;"
   latex:
@@ -15004,9 +15028,9 @@
   html:
   - "&#x2acb;"
 - unicodemath:
-  - __{subsetplus}
+  - '"P{subsetplus}"'
   asciimath:
-  - __{subsetplus}
+  - '"P{subsetplus}"'
   mathml:
   - "&#x2abf;"
   latex:
@@ -15016,9 +15040,9 @@
   html:
   - "&#x2abf;"
 - unicodemath:
-  - __{subsim}
+  - '"P{subsim}"'
   asciimath:
-  - __{subsim}
+  - '"P{subsim}"'
   mathml:
   - "&#x2ac7;"
   latex:
@@ -15029,22 +15053,22 @@
   - "&#x2ac7;"
 - unicodemath:
   - subsub
-  - __{subsup}
+  - '"P{subsup}"'
   asciimath:
-  - __{subsub}
-  - __{subsup}
+  - '"P{subsub}"'
+  - '"P{subsup}"'
   mathml:
   - "&#x2ad3;"
   latex:
   - subsup
-  - __{subsub}
+  - "\\text{P[subsub]}"
   omml:
   - "&#x2ad3;"
   html:
   - "&#x2ad3;"
 - unicodemath:
   - succ
-  - __{>-}
+  - '"P{>-}"'
   asciimath:
   - succ
   - ">-"
@@ -15052,15 +15076,15 @@
   - "&#x227b;"
   latex:
   - succ
-  - __{>-}
+  - "\\text{P[>-]}"
   omml:
   - "&#x227b;"
   html:
   - "&#x227b;"
 - unicodemath:
-  - __{succapprox}
+  - '"P{succapprox}"'
   asciimath:
-  - __{succapprox}
+  - '"P{succapprox}"'
   mathml:
   - "&#x2ab8;"
   latex:
@@ -15071,10 +15095,10 @@
   - "&#x2ab8;"
 - unicodemath:
   - succcurlyeq
-  - __{SucceedsSlantEqual}
+  - '"P{SucceedsSlantEqual}"'
   asciimath:
-  - __{succcurlyeq}
-  - __{SucceedsSlantEqual}
+  - '"P{succcurlyeq}"'
+  - '"P{SucceedsSlantEqual}"'
   mathml:
   - "&#x227d;"
   latex:
@@ -15086,7 +15110,7 @@
   - "&#x227d;"
 - unicodemath:
   - succeq
-  - __{>-=}
+  - '"P{>-=}"'
   asciimath:
   - succeq
   - ">-="
@@ -15094,15 +15118,15 @@
   - "&#x2ab0;"
   latex:
   - succeq
-  - __{>-=}
+  - "\\text{P[>-=]}"
   omml:
   - "&#x2ab0;"
   html:
   - "&#x2ab0;"
 - unicodemath:
-  - __{succeqq}
+  - '"P{succeqq}"'
   asciimath:
-  - __{succeqq}
+  - '"P{succeqq}"'
   mathml:
   - "&#x2ab4;"
   latex:
@@ -15112,9 +15136,9 @@
   html:
   - "&#x2ab4;"
 - unicodemath:
-  - __{succnapprox}
+  - '"P{succnapprox}"'
   asciimath:
-  - __{succnapprox}
+  - '"P{succnapprox}"'
   mathml:
   - "&#x2aba;"
   latex:
@@ -15124,9 +15148,9 @@
   html:
   - "&#x2aba;"
 - unicodemath:
-  - __{succneq}
+  - '"P{succneq}"'
   asciimath:
-  - __{succneq}
+  - '"P{succneq}"'
   mathml:
   - "&#x2ab2;"
   latex:
@@ -15136,9 +15160,9 @@
   html:
   - "&#x2ab2;"
 - unicodemath:
-  - __{succneqq}
+  - '"P{succneqq}"'
   asciimath:
-  - __{succneqq}
+  - '"P{succneqq}"'
   mathml:
   - "&#x2ab6;"
   latex:
@@ -15150,7 +15174,7 @@
 - unicodemath:
   - succnsim
   asciimath:
-  - __{succnsim}
+  - '"P{succnsim}"'
   mathml:
   - "&#x22e9;"
   latex:
@@ -15161,10 +15185,10 @@
   - "&#x22e9;"
 - unicodemath:
   - succsim
-  - __{SucceedsTilde}
+  - '"P{SucceedsTilde}"'
   asciimath:
-  - __{succsim}
-  - __{SucceedsTilde}
+  - '"P{succsim}"'
+  - '"P{SucceedsTilde}"'
   mathml:
   - "&#x227f;"
   latex:
@@ -15187,9 +15211,9 @@
   html:
   - "&#x2211;"
 - unicodemath:
-  - __{sumbottom}
+  - '"P{sumbottom}"'
   asciimath:
-  - __{sumbottom}
+  - '"P{sumbottom}"'
   mathml:
   - "&#x23b3;"
   latex:
@@ -15199,9 +15223,9 @@
   html:
   - "&#x23b3;"
 - unicodemath:
-  - __{sumint}
+  - '"P{sumint}"'
   asciimath:
-  - __{sumint}
+  - '"P{sumint}"'
   mathml:
   - "&#x2a0b;"
   latex:
@@ -15211,9 +15235,9 @@
   html:
   - "&#x2a0b;"
 - unicodemath:
-  - __{sumtop}
+  - '"P{sumtop}"'
   asciimath:
-  - __{sumtop}
+  - '"P{sumtop}"'
   mathml:
   - "&#x23b2;"
   latex:
@@ -15223,9 +15247,9 @@
   html:
   - "&#x23b2;"
 - unicodemath:
-  - __{sun}
+  - '"P{sun}"'
   asciimath:
-  - __{sun}
+  - '"P{sun}"'
   mathml:
   - "&#x263c;"
   latex:
@@ -15236,7 +15260,7 @@
   - "&#x263c;"
 - unicodemath:
   - supset
-  - __{sup}
+  - '"P{sup}"'
   asciimath:
   - supset
   - sup
@@ -15244,15 +15268,15 @@
   - "&#x2283;"
   latex:
   - supset
-  - __{sup}
+  - "\\text{P[sup]}"
   omml:
   - "&#x2283;"
   html:
   - "&#x2283;"
 - unicodemath:
-  - __{supdsub}
+  - '"P{supdsub}"'
   asciimath:
-  - __{supdsub}
+  - '"P{supdsub}"'
   mathml:
   - "&#x2ad8;"
   latex:
@@ -15263,7 +15287,7 @@
   - "&#x2ad8;"
 - unicodemath:
   - supseteq
-  - __{supe}
+  - '"P{supe}"'
   asciimath:
   - supseteq
   - supe
@@ -15271,15 +15295,15 @@
   - "&#x2287;"
   latex:
   - supseteq
-  - __{supe}
+  - "\\text{P[supe]}"
   omml:
   - "&#x2287;"
   html:
   - "&#x2287;"
 - unicodemath:
-  - __{supedot}
+  - '"P{supedot}"'
   asciimath:
-  - __{supedot}
+  - '"P{supedot}"'
   mathml:
   - "&#x2ac4;"
   latex:
@@ -15289,9 +15313,9 @@
   html:
   - "&#x2ac4;"
 - unicodemath:
-  - __{suphsol}
+  - '"P{suphsol}"'
   asciimath:
-  - __{suphsol}
+  - '"P{suphsol}"'
   mathml:
   - "&#x27c9;"
   latex:
@@ -15301,9 +15325,9 @@
   html:
   - "&#x27c9;"
 - unicodemath:
-  - __{suphsub}
+  - '"P{suphsub}"'
   asciimath:
-  - __{suphsub}
+  - '"P{suphsub}"'
   mathml:
   - "&#x2ad7;"
   latex:
@@ -15313,9 +15337,9 @@
   html:
   - "&#x2ad7;"
 - unicodemath:
-  - __{suplarr}
+  - '"P{suplarr}"'
   asciimath:
-  - __{suplarr}
+  - '"P{suplarr}"'
   mathml:
   - "&#x297b;"
   latex:
@@ -15325,9 +15349,9 @@
   html:
   - "&#x297b;"
 - unicodemath:
-  - __{supmult}
+  - '"P{supmult}"'
   asciimath:
-  - __{supmult}
+  - '"P{supmult}"'
   mathml:
   - "&#x2ac2;"
   latex:
@@ -15339,7 +15363,7 @@
 - unicodemath:
   - Supset
   asciimath:
-  - __{Supset}
+  - '"P{Supset}"'
   mathml:
   - "&#x22d1;"
   latex:
@@ -15349,9 +15373,9 @@
   html:
   - "&#x22d1;"
 - unicodemath:
-  - __{supsetapprox}
+  - '"P{supsetapprox}"'
   asciimath:
-  - __{supsetapprox}
+  - '"P{supsetapprox}"'
   mathml:
   - "&#x2aca;"
   latex:
@@ -15361,9 +15385,9 @@
   html:
   - "&#x2aca;"
 - unicodemath:
-  - __{supsetcirc}
+  - '"P{supsetcirc}"'
   asciimath:
-  - __{supsetcirc}
+  - '"P{supsetcirc}"'
   mathml:
   - "&#x27c4;"
   latex:
@@ -15373,9 +15397,9 @@
   html:
   - "&#x27c4;"
 - unicodemath:
-  - __{supsetdot}
+  - '"P{supsetdot}"'
   asciimath:
-  - __{supsetdot}
+  - '"P{supsetdot}"'
   mathml:
   - "&#x2abe;"
   latex:
@@ -15386,7 +15410,7 @@
   - "&#x2abe;"
 - unicodemath:
   - supseteq
-  - __{supe}
+  - '"P{supe}"'
   asciimath:
   - supseteq
   - supe
@@ -15394,15 +15418,15 @@
   - "&#x2287;"
   latex:
   - supseteq
-  - __{supe}
+  - "\\text{P[supe]}"
   omml:
   - "&#x2287;"
   html:
   - "&#x2287;"
 - unicodemath:
-  - __{supseteqq}
+  - '"P{supseteqq}"'
   asciimath:
-  - __{supseteqq}
+  - '"P{supseteqq}"'
   mathml:
   - "&#x2ac6;"
   latex:
@@ -15414,7 +15438,7 @@
 - unicodemath:
   - supsetneq
   asciimath:
-  - __{supsetneq}
+  - '"P{supsetneq}"'
   mathml:
   - "&#x228b;"
   latex:
@@ -15424,9 +15448,9 @@
   html:
   - "&#x228b;"
 - unicodemath:
-  - __{supsetneqq}
+  - '"P{supsetneqq}"'
   asciimath:
-  - __{supsetneqq}
+  - '"P{supsetneqq}"'
   mathml:
   - "&#x2acc;"
   latex:
@@ -15436,9 +15460,9 @@
   html:
   - "&#x2acc;"
 - unicodemath:
-  - __{supsetplus}
+  - '"P{supsetplus}"'
   asciimath:
-  - __{supsetplus}
+  - '"P{supsetplus}"'
   mathml:
   - "&#x2ac0;"
   latex:
@@ -15448,9 +15472,9 @@
   html:
   - "&#x2ac0;"
 - unicodemath:
-  - __{supsim}
+  - '"P{supsim}"'
   asciimath:
-  - __{supsim}
+  - '"P{supsim}"'
   mathml:
   - "&#x2ac8;"
   latex:
@@ -15462,7 +15486,7 @@
 - unicodemath:
   - supsub
   asciimath:
-  - __{supsub}
+  - '"P{supsub}"'
   mathml:
   - "&#x2ad4;"
   latex:
@@ -15474,7 +15498,7 @@
 - unicodemath:
   - supsup
   asciimath:
-  - __{supsup}
+  - '"P{supsup}"'
   mathml:
   - "&#x2ad6;"
   latex:
@@ -15484,9 +15508,9 @@
   html:
   - "&#x2ad6;"
 - unicodemath:
-  - __{Swarrow}
+  - '"P{Swarrow}"'
   asciimath:
-  - __{Swarrow}
+  - '"P{Swarrow}"'
   mathml:
   - "&#x21d9;"
   latex:
@@ -15496,9 +15520,9 @@
   html:
   - "&#x21d9;"
 - unicodemath:
-  - __{swords}
+  - '"P{swords}"'
   asciimath:
-  - __{swords}
+  - '"P{swords}"'
   mathml:
   - "&#x2694;"
   latex:
@@ -15507,11 +15531,10 @@
   - "&#x2694;"
   html:
   - "&#x2694;"
-- {}
 - unicodemath:
-  - __{talloblong}
+  - '"P{talloblong}"'
   asciimath:
-  - __{talloblong}
+  - '"P{talloblong}"'
   mathml:
   - "&#x2afe;"
   latex:
@@ -15522,10 +15545,10 @@
   - "&#x2afe;"
 - unicodemath:
   - tau
-  - __{uptau}
+  - '"P{uptau}"'
   asciimath:
   - tau
-  - __{uptau}
+  - '"P{uptau}"'
   mathml:
   - "&#x3c4;"
   latex:
@@ -15536,11 +15559,11 @@
   html:
   - "&#x3c4;"
 - unicodemath:
-  - __{taurus}
-  - __{Taurus}
+  - '"P{taurus}"'
+  - '"P{Taurus}"'
   asciimath:
-  - __{taurus}
-  - __{Taurus}
+  - '"P{taurus}"'
+  - '"P{Taurus}"'
   mathml:
   - "&#x2649;"
   latex:
@@ -15551,11 +15574,11 @@
   html:
   - "&#x2649;"
 - unicodemath:
-  - __{Micro}
-  - __{tcmu}
+  - '"P{Micro}"'
+  - '"P{tcmu}"'
   asciimath:
-  - __{Micro}
-  - __{tcmu}
+  - '"P{Micro}"'
+  - '"P{tcmu}"'
   mathml:
   - "&#xb5;"
   latex:
@@ -15566,9 +15589,9 @@
   html:
   - "&#xb5;"
 - unicodemath:
-  - __{tcohm}
+  - '"P{tcohm}"'
   asciimath:
-  - __{tcohm}
+  - '"P{tcohm}"'
   mathml:
   - "&#x2126;"
   latex:
@@ -15579,26 +15602,26 @@
   - "&#x2126;"
 - unicodemath:
   - therefore
-  - __{:.}
-  - __{wasytherefore}
+  - '"P{:.}"'
+  - '"P{wasytherefore}"'
   asciimath:
   - therefore
   - ":."
-  - __{wasytherefore}
+  - '"P{wasytherefore}"'
   mathml:
   - "&#x2234;"
   latex:
   - wasytherefore
   - therefore
-  - __{:.}
+  - "\\text{P[:.]}"
   omml:
   - "&#x2234;"
   html:
   - "&#x2234;"
 - unicodemath:
-  - __{thermod}
+  - '"P{thermod}"'
   asciimath:
-  - __{thermod}
+  - '"P{thermod}"'
   mathml:
   - "&#x29e7;"
   latex:
@@ -15609,25 +15632,22 @@
   - "&#x29e7;"
 - unicodemath:
   - theta
-  - __{uptheta}
+  - '"P{uptheta}"'
   asciimath:
   - theta
-  - __{uptheta}
-  mathml:
-  - "&#x3b8;"
+  - '"P{uptheta}"'
+  mathml: []
   latex:
   - uptheta
   - theta
-  omml:
-  - "&#x3b8;"
-  html:
-  - "&#x3b8;"
+  omml: []
+  html: []
 - unicodemath:
-  - __{trprime}
-  - __{third}
+  - '"P{trprime}"'
+  - '"P{third}"'
   asciimath:
-  - __{trprime}
-  - __{third}
+  - '"P{trprime}"'
+  - '"P{third}"'
   mathml:
   - "&#x2034;"
   latex:
@@ -15638,9 +15658,9 @@
   html:
   - "&#x2034;"
 - unicodemath:
-  - __{threedangle}
+  - '"P{threedangle}"'
   asciimath:
-  - __{threedangle}
+  - '"P{threedangle}"'
   mathml:
   - "&#x27c0;"
   latex:
@@ -15650,9 +15670,9 @@
   html:
   - "&#x27c0;"
 - unicodemath:
-  - __{threedotcolon}
+  - '"P{threedotcolon}"'
   asciimath:
-  - __{threedotcolon}
+  - '"P{threedotcolon}"'
   mathml:
   - "&#x2af6;"
   latex:
@@ -15662,9 +15682,9 @@
   html:
   - "&#x2af6;"
 - unicodemath:
-  - __{threeunderdot}
+  - '"P{threeunderdot}"'
   asciimath:
-  - __{threeunderdot}
+  - '"P{threeunderdot}"'
   mathml:
   - "&#x20e8;"
   latex:
@@ -15674,9 +15694,9 @@
   html:
   - "&#x20e8;"
 - unicodemath:
-  - __{tieinfty}
+  - '"P{tieinfty}"'
   asciimath:
-  - __{tieinfty}
+  - '"P{tieinfty}"'
   mathml:
   - "&#x29dd;"
   latex:
@@ -15699,23 +15719,26 @@
   - "~"
 - unicodemath:
   - times
-  - __{xx}
+  - "&times;"
+  - '"P{xx}"'
   asciimath:
   - times
   - xx
+  - "&times;"
   mathml:
-  - "&#xd7;"
+  - "&times;"
   latex:
   - times
-  - __{xx}
+  - "&times;"
+  - "\\text{P[xx]}"
   omml:
-  - "&#xd7;"
+  - "&times;"
   html:
-  - "&#xd7;"
+  - "&times;"
 - unicodemath:
-  - __{timesbar}
+  - '"P{timesbar}"'
   asciimath:
-  - __{timesbar}
+  - '"P{timesbar}"'
   mathml:
   - "&#x2a31;"
   latex:
@@ -15726,26 +15749,26 @@
   - "&#x2a31;"
 - unicodemath:
   - rightarrowtail
-  - __{>->}
-  - __{tinj}
+  - '"P{>->}"'
+  - '"P{tinj}"'
   asciimath:
   - rightarrowtail
   - ">->"
-  - __{tinj}
+  - '"P{tinj}"'
   mathml:
   - "&#x21a3;"
   latex:
   - rightarrowtail
   - tinj
-  - __{>->}
+  - "\\text{P[>->]}"
   omml:
   - "&#x21a3;"
   html:
   - "&#x21a3;"
 - unicodemath:
-  - __{tminus}
+  - '"P{tminus}"'
   asciimath:
-  - __{tminus}
+  - '"P{tminus}"'
   mathml:
   - "&#x29ff;"
   latex:
@@ -15757,8 +15780,8 @@
 - unicodemath:
   - rightarrow
   - to
-  - __{rarr}
-  - __{->}
+  - '"P{rarr}"'
+  - '"P{->}"'
   asciimath:
   - rightarrow
   - rarr
@@ -15769,16 +15792,16 @@
   latex:
   - rightarrow
   - to
-  - __{rarr}
-  - __{->}
+  - "\\text{P[rarr]}"
+  - "\\text{P[->]}"
   omml:
   - "&#x2192;"
   html:
   - "&#x2192;"
 - unicodemath:
-  - __{toea}
+  - '"P{toea}"'
   asciimath:
-  - __{toea}
+  - '"P{toea}"'
   mathml:
   - "&#x2928;"
   latex:
@@ -15788,9 +15811,9 @@
   html:
   - "&#x2928;"
 - unicodemath:
-  - __{tona}
+  - '"P{tona}"'
   asciimath:
-  - __{tona}
+  - '"P{tona}"'
   mathml:
   - "&#x2927;"
   latex:
@@ -15801,7 +15824,7 @@
   - "&#x2927;"
 - unicodemath:
   - top
-  - __{TT}
+  - '"P{TT}"'
   asciimath:
   - top
   - TT
@@ -15809,15 +15832,15 @@
   - "&#x22a4;"
   latex:
   - top
-  - __{TT}
+  - "\\text{P[TT]}"
   omml:
   - "&#x22a4;"
   html:
   - "&#x22a4;"
 - unicodemath:
-  - __{topbot}
+  - '"P{topbot}"'
   asciimath:
-  - __{topbot}
+  - '"P{topbot}"'
   mathml:
   - "&#x2336;"
   latex:
@@ -15827,9 +15850,9 @@
   html:
   - "&#x2336;"
 - unicodemath:
-  - __{topcir}
+  - '"P{topcir}"'
   asciimath:
-  - __{topcir}
+  - '"P{topcir}"'
   mathml:
   - "&#x2af1;"
   latex:
@@ -15839,9 +15862,9 @@
   html:
   - "&#x2af1;"
 - unicodemath:
-  - __{topfork}
+  - '"P{topfork}"'
   asciimath:
-  - __{topfork}
+  - '"P{topfork}"'
   mathml:
   - "&#x2ada;"
   latex:
@@ -15851,9 +15874,9 @@
   html:
   - "&#x2ada;"
 - unicodemath:
-  - __{topsemicircle}
+  - '"P{topsemicircle}"'
   asciimath:
-  - __{topsemicircle}
+  - '"P{topsemicircle}"'
   mathml:
   - "&#x25e0;"
   latex:
@@ -15863,9 +15886,9 @@
   html:
   - "&#x25e0;"
 - unicodemath:
-  - __{tosa}
+  - '"P{tosa}"'
   asciimath:
-  - __{tosa}
+  - '"P{tosa}"'
   mathml:
   - "&#x2929;"
   latex:
@@ -15875,9 +15898,9 @@
   html:
   - "&#x2929;"
 - unicodemath:
-  - __{towa}
+  - '"P{towa}"'
   asciimath:
-  - __{towa}
+  - '"P{towa}"'
   mathml:
   - "&#x292a;"
   latex:
@@ -15887,9 +15910,9 @@
   html:
   - "&#x292a;"
 - unicodemath:
-  - __{tplus}
+  - '"P{tplus}"'
   asciimath:
-  - __{tplus}
+  - '"P{tplus}"'
   mathml:
   - "&#x29fe;"
   latex:
@@ -15899,9 +15922,9 @@
   html:
   - "&#x29fe;"
 - unicodemath:
-  - __{trapezium}
+  - '"P{trapezium}"'
   asciimath:
-  - __{trapezium}
+  - '"P{trapezium}"'
   mathml:
   - "&#x23e2;"
   latex:
@@ -15912,26 +15935,26 @@
   - "&#x23e2;"
 - unicodemath:
   - triangle
-  - __{/_\}
-  - __{bigtriangleup}
+  - '"P{/_\}"'
+  - '"P{bigtriangleup}"'
   asciimath:
   - triangle
   - "/_\\"
-  - __{bigtriangleup}
+  - '"P{bigtriangleup}"'
   mathml:
   - "&#x25b3;"
   latex:
   - bigtriangleup
   - triangle
-  - __{/_\}
+  - "\\text{P[/_\\]}"
   omml:
   - "&#x25b3;"
   html:
   - "&#x25b3;"
 - unicodemath:
-  - __{trianglecdot}
+  - '"P{trianglecdot}"'
   asciimath:
-  - __{trianglecdot}
+  - '"P{trianglecdot}"'
   mathml:
   - "&#x25ec;"
   latex:
@@ -15941,11 +15964,11 @@
   html:
   - "&#x25ec;"
 - unicodemath:
-  - __{smalltriangledown}
-  - __{triangledown}
+  - '"P{smalltriangledown}"'
+  - '"P{triangledown}"'
   asciimath:
-  - __{smalltriangledown}
-  - __{triangledown}
+  - '"P{smalltriangledown}"'
+  - '"P{triangledown}"'
   mathml:
   - "&#x25bf;"
   latex:
@@ -15956,9 +15979,9 @@
   html:
   - "&#x25bf;"
 - unicodemath:
-  - __{triangleleftblack}
+  - '"P{triangleleftblack}"'
   asciimath:
-  - __{triangleleftblack}
+  - '"P{triangleleftblack}"'
   mathml:
   - "&#x25ed;"
   latex:
@@ -15968,9 +15991,9 @@
   html:
   - "&#x25ed;"
 - unicodemath:
-  - __{triangleminus}
+  - '"P{triangleminus}"'
   asciimath:
-  - __{triangleminus}
+  - '"P{triangleminus}"'
   mathml:
   - "&#x2a3a;"
   latex:
@@ -15980,9 +16003,9 @@
   html:
   - "&#x2a3a;"
 - unicodemath:
-  - __{triangleodot}
+  - '"P{triangleodot}"'
   asciimath:
-  - __{triangleodot}
+  - '"P{triangleodot}"'
   mathml:
   - "&#x29ca;"
   latex:
@@ -15992,9 +16015,9 @@
   html:
   - "&#x29ca;"
 - unicodemath:
-  - __{triangleplus}
+  - '"P{triangleplus}"'
   asciimath:
-  - __{triangleplus}
+  - '"P{triangleplus}"'
   mathml:
   - "&#x2a39;"
   latex:
@@ -16004,9 +16027,9 @@
   html:
   - "&#x2a39;"
 - unicodemath:
-  - __{trianglerightblack}
+  - '"P{trianglerightblack}"'
   asciimath:
-  - __{trianglerightblack}
+  - '"P{trianglerightblack}"'
   mathml:
   - "&#x25ee;"
   latex:
@@ -16016,9 +16039,9 @@
   html:
   - "&#x25ee;"
 - unicodemath:
-  - __{triangles}
+  - '"P{triangles}"'
   asciimath:
-  - __{triangles}
+  - '"P{triangles}"'
   mathml:
   - "&#x29cc;"
   latex:
@@ -16028,9 +16051,9 @@
   html:
   - "&#x29cc;"
 - unicodemath:
-  - __{triangleserifs}
+  - '"P{triangleserifs}"'
   asciimath:
-  - __{triangleserifs}
+  - '"P{triangleserifs}"'
   mathml:
   - "&#x29cd;"
   latex:
@@ -16040,9 +16063,9 @@
   html:
   - "&#x29cd;"
 - unicodemath:
-  - __{triangletimes}
+  - '"P{triangletimes}"'
   asciimath:
-  - __{triangletimes}
+  - '"P{triangletimes}"'
   mathml:
   - "&#x2a3b;"
   latex:
@@ -16052,9 +16075,9 @@
   html:
   - "&#x2a3b;"
 - unicodemath:
-  - __{triangleubar}
+  - '"P{triangleubar}"'
   asciimath:
-  - __{triangleubar}
+  - '"P{triangleubar}"'
   mathml:
   - "&#x29cb;"
   latex:
@@ -16064,9 +16087,9 @@
   html:
   - "&#x29cb;"
 - unicodemath:
-  - __{tripleplus}
+  - '"P{tripleplus}"'
   asciimath:
-  - __{tripleplus}
+  - '"P{tripleplus}"'
   mathml:
   - "&#x29fb;"
   latex:
@@ -16076,9 +16099,9 @@
   html:
   - "&#x29fb;"
 - unicodemath:
-  - __{trslash}
+  - '"P{trslash}"'
   asciimath:
-  - __{trslash}
+  - '"P{trslash}"'
   mathml:
   - "&#x2afb;"
   latex:
@@ -16089,25 +16112,25 @@
   - "&#x2afb;"
 - unicodemath:
   - twoheadrightarrow
-  - __{->>}
-  - __{tsur}
+  - '"P{->>}"'
+  - '"P{tsur}"'
   asciimath:
   - twoheadrightarrow
   - "->>"
-  - __{tsur}
+  - '"P{tsur}"'
   mathml:
   - "&#x21a0;"
   latex:
   - twoheadrightarrow
   - tsur
-  - __{->>}
+  - "\\text{P[->>]}"
   omml:
   - "&#x21a0;"
   html:
   - "&#x21a0;"
 - unicodemath:
   - top
-  - __{TT}
+  - '"P{TT}"'
   asciimath:
   - top
   - TT
@@ -16115,15 +16138,15 @@
   - "&#x22a4;"
   latex:
   - top
-  - __{TT}
+  - "\\text{P[TT]}"
   omml:
   - "&#x22a4;"
   html:
   - "&#x22a4;"
 - unicodemath:
-  - __{turnangle}
+  - '"P{turnangle}"'
   asciimath:
-  - __{turnangle}
+  - '"P{turnangle}"'
   mathml:
   - "&#x29a2;"
   latex:
@@ -16133,9 +16156,9 @@
   html:
   - "&#x29a2;"
 - unicodemath:
-  - __{turnediota}
+  - '"P{turnediota}"'
   asciimath:
-  - __{turnediota}
+  - '"P{turnediota}"'
   mathml:
   - "&#x2129;"
   latex:
@@ -16145,9 +16168,9 @@
   html:
   - "&#x2129;"
 - unicodemath:
-  - __{turnednot}
+  - '"P{turnednot}"'
   asciimath:
-  - __{turnednot}
+  - '"P{turnednot}"'
   mathml:
   - "&#x2319;"
   latex:
@@ -16157,9 +16180,9 @@
   html:
   - "&#x2319;"
 - unicodemath:
-  - __{twocaps}
+  - '"P{twocaps}"'
   asciimath:
-  - __{twocaps}
+  - '"P{twocaps}"'
   mathml:
   - "&#x2a4b;"
   latex:
@@ -16169,9 +16192,9 @@
   html:
   - "&#x2a4b;"
 - unicodemath:
-  - __{twocups}
+  - '"P{twocups}"'
   asciimath:
-  - __{twocups}
+  - '"P{twocups}"'
   mathml:
   - "&#x2a4a;"
   latex:
@@ -16181,9 +16204,9 @@
   html:
   - "&#x2a4a;"
 - unicodemath:
-  - __{twoheaddownarrow}
+  - '"P{twoheaddownarrow}"'
   asciimath:
-  - __{twoheaddownarrow}
+  - '"P{twoheaddownarrow}"'
   mathml:
   - "&#x21a1;"
   latex:
@@ -16195,7 +16218,7 @@
 - unicodemath:
   - twoheadleftarrow
   asciimath:
-  - __{twoheadleftarrow}
+  - '"P{twoheadleftarrow}"'
   mathml:
   - "&#x219e;"
   latex:
@@ -16205,9 +16228,9 @@
   html:
   - "&#x219e;"
 - unicodemath:
-  - __{twoheadleftarrowtail}
+  - '"P{twoheadleftarrowtail}"'
   asciimath:
-  - __{twoheadleftarrowtail}
+  - '"P{twoheadleftarrowtail}"'
   mathml:
   - "&#x2b3b;"
   latex:
@@ -16217,9 +16240,9 @@
   html:
   - "&#x2b3b;"
 - unicodemath:
-  - __{twoheadleftdbkarrow}
+  - '"P{twoheadleftdbkarrow}"'
   asciimath:
-  - __{twoheadleftdbkarrow}
+  - '"P{twoheadleftdbkarrow}"'
   mathml:
   - "&#x2b37;"
   latex:
@@ -16229,9 +16252,9 @@
   html:
   - "&#x2b37;"
 - unicodemath:
-  - __{twoheadmapsfrom}
+  - '"P{twoheadmapsfrom}"'
   asciimath:
-  - __{twoheadmapsfrom}
+  - '"P{twoheadmapsfrom}"'
   mathml:
   - "&#x2b36;"
   latex:
@@ -16241,9 +16264,9 @@
   html:
   - "&#x2b36;"
 - unicodemath:
-  - __{twoheadmapsto}
+  - '"P{twoheadmapsto}"'
   asciimath:
-  - __{twoheadmapsto}
+  - '"P{twoheadmapsto}"'
   mathml:
   - "&#x2905;"
   latex:
@@ -16254,44 +16277,44 @@
   - "&#x2905;"
 - unicodemath:
   - twoheadrightarrow
-  - __{->>}
-  - __{tsur}
+  - '"P{->>}"'
+  - '"P{tsur}"'
   asciimath:
   - twoheadrightarrow
   - "->>"
-  - __{tsur}
+  - '"P{tsur}"'
   mathml:
   - "&#x21a0;"
   latex:
   - twoheadrightarrow
   - tsur
-  - __{->>}
+  - "\\text{P[->>]}"
   omml:
   - "&#x21a0;"
   html:
   - "&#x21a0;"
 - unicodemath:
-  - __{twoheadrightarrowtail}
-  - __{>->>}
-  - __{bij}
+  - '"P{twoheadrightarrowtail}"'
+  - '"P{>->>}"'
+  - '"P{bij}"'
   asciimath:
   - twoheadrightarrowtail
   - ">->>"
-  - __{bij}
+  - '"P{bij}"'
   mathml:
   - "&#x2916;"
   latex:
   - twoheadrightarrowtail
   - bij
-  - __{>->>}
+  - "\\text{P[>->>]}"
   omml:
   - "&#x2916;"
   html:
   - "&#x2916;"
 - unicodemath:
-  - __{twoheaduparrow}
+  - '"P{twoheaduparrow}"'
   asciimath:
-  - __{twoheaduparrow}
+  - '"P{twoheaduparrow}"'
   mathml:
   - "&#x219f;"
   latex:
@@ -16301,9 +16324,9 @@
   html:
   - "&#x219f;"
 - unicodemath:
-  - __{twoheaduparrowcircle}
+  - '"P{twoheaduparrowcircle}"'
   asciimath:
-  - __{twoheaduparrowcircle}
+  - '"P{twoheaduparrowcircle}"'
   mathml:
   - "&#x2949;"
   latex:
@@ -16313,9 +16336,9 @@
   html:
   - "&#x2949;"
 - unicodemath:
-  - __{twolowline}
+  - '"P{twolowline}"'
   asciimath:
-  - __{twolowline}
+  - '"P{twolowline}"'
   mathml:
   - "&#x2017;"
   latex:
@@ -16325,9 +16348,9 @@
   html:
   - "&#x2017;"
 - unicodemath:
-  - __{twonotes}
+  - '"P{twonotes}"'
   asciimath:
-  - __{twonotes}
+  - '"P{twonotes}"'
   mathml:
   - "&#x266b;"
   latex:
@@ -16337,9 +16360,9 @@
   html:
   - "&#x266b;"
 - unicodemath:
-  - __{typecolon}
+  - '"P{typecolon}"'
   asciimath:
-  - __{typecolon}
+  - '"P{typecolon}"'
   mathml:
   - "&#x2982;"
   latex:
@@ -16350,7 +16373,7 @@
   - "&#x2982;"
 - unicodemath:
   - uparrow
-  - __{uarr}
+  - '"P{uarr}"'
   asciimath:
   - uparrow
   - uarr
@@ -16358,7 +16381,7 @@
   - "&#x2191;"
   latex:
   - uparrow
-  - __{uarr}
+  - "\\text{P[uarr]}"
   omml:
   - "&#x2191;"
   html:
@@ -16376,9 +16399,9 @@
   html:
   - "&#x23df;"
 - unicodemath:
-  - __{ubrbrak}
+  - '"P{ubrbrak}"'
   asciimath:
-  - __{ubrbrak}
+  - '"P{ubrbrak}"'
   mathml:
   - "&#x23e1;"
   latex:
@@ -16400,9 +16423,9 @@
   html:
   - _
 - unicodemath:
-  - __{ularc}
+  - '"P{ularc}"'
   asciimath:
-  - __{ularc}
+  - '"P{ularc}"'
   mathml:
   - "&#x25dc;"
   latex:
@@ -16412,9 +16435,9 @@
   html:
   - "&#x25dc;"
 - unicodemath:
-  - __{ulblacktriangle}
+  - '"P{ulblacktriangle}"'
   asciimath:
-  - __{ulblacktriangle}
+  - '"P{ulblacktriangle}"'
   mathml:
   - "&#x25e4;"
   latex:
@@ -16424,9 +16447,9 @@
   html:
   - "&#x25e4;"
 - unicodemath:
-  - __{ulcorner}
+  - '"P{ulcorner}"'
   asciimath:
-  - __{ulcorner}
+  - '"P{ulcorner}"'
   mathml:
   - "&#x231c;"
   latex:
@@ -16436,9 +16459,9 @@
   html:
   - "&#x231c;"
 - unicodemath:
-  - __{ultriangle}
+  - '"P{ultriangle}"'
   asciimath:
-  - __{ultriangle}
+  - '"P{ultriangle}"'
   mathml:
   - "&#x25f8;"
   latex:
@@ -16448,9 +16471,9 @@
   html:
   - "&#x25f8;"
 - unicodemath:
-  - __{uminus}
+  - '"P{uminus}"'
   asciimath:
-  - __{uminus}
+  - '"P{uminus}"'
   mathml:
   - "&#x2a41;"
   latex:
@@ -16460,9 +16483,9 @@
   html:
   - "&#x2a41;"
 - unicodemath:
-  - __{underbar}
+  - '"P{underbar}"'
   asciimath:
-  - __{underbar}
+  - '"P{underbar}"'
   mathml:
   - "&#x331;"
   latex:
@@ -16472,9 +16495,9 @@
   html:
   - "&#x331;"
 - unicodemath:
-  - __{underbracket}
+  - '"P{underbracket}"'
   asciimath:
-  - __{underbracket}
+  - '"P{underbracket}"'
   mathml:
   - "&#x23b5;"
   latex:
@@ -16484,9 +16507,9 @@
   html:
   - "&#x23b5;"
 - unicodemath:
-  - __{underleftarrow}
+  - '"P{underleftarrow}"'
   asciimath:
-  - __{underleftarrow}
+  - '"P{underleftarrow}"'
   mathml:
   - "&#x20ee;"
   latex:
@@ -16496,9 +16519,9 @@
   html:
   - "&#x20ee;"
 - unicodemath:
-  - __{underleftharpoondown}
+  - '"P{underleftharpoondown}"'
   asciimath:
-  - __{underleftharpoondown}
+  - '"P{underleftharpoondown}"'
   mathml:
   - "&#x20ed;"
   latex:
@@ -16508,9 +16531,9 @@
   html:
   - "&#x20ed;"
 - unicodemath:
-  - __{underline}
+  - '"P{underline}"'
   asciimath:
-  - __{underline}
+  - '"P{underline}"'
   mathml:
   - "&#x332;"
   latex:
@@ -16520,9 +16543,9 @@
   html:
   - "&#x332;"
 - unicodemath:
-  - __{underparen}
+  - '"P{underparen}"'
   asciimath:
-  - __{underparen}
+  - '"P{underparen}"'
   mathml:
   - "&#x23dd;"
   latex:
@@ -16532,9 +16555,9 @@
   html:
   - "&#x23dd;"
 - unicodemath:
-  - __{underrightarrow}
+  - '"P{underrightarrow}"'
   asciimath:
-  - __{underrightarrow}
+  - '"P{underrightarrow}"'
   mathml:
   - "&#x20ef;"
   latex:
@@ -16544,9 +16567,9 @@
   html:
   - "&#x20ef;"
 - unicodemath:
-  - __{underrightharpoondown}
+  - '"P{underrightharpoondown}"'
   asciimath:
-  - __{underrightharpoondown}
+  - '"P{underrightharpoondown}"'
   mathml:
   - "&#x20ec;"
   latex:
@@ -16556,47 +16579,23 @@
   html:
   - "&#x20ec;"
 - unicodemath:
-  - __{cdots}
-  - __{unicodecdots}
+  - '"P{unicodeellipsis}"'
   asciimath:
-  - cdots
-  - __{unicodecdots}
-  mathml:
-  - "&#x22ef;"
-  latex:
-  - unicodecdots
-  - cdots
-  omml:
-  - "&#x22ef;"
-  html:
-  - "&#x22ef;"
-- unicodemath:
-  - ldots
-  - "..."
-  - dots
-  - __{unicodeellipsis}
-  asciimath:
-  - ldots
-  - "..."
-  - __{dots}
-  - __{unicodeellipsis}
+  - '"P{unicodeellipsis}"'
   mathml:
   - "&#x2026;"
   latex:
   - unicodeellipsis
-  - ldots
-  - __{...}
-  - __{dots}
   omml:
   - "&#x2026;"
   html:
   - "&#x2026;"
 - unicodemath:
   - trianglelefteq
-  - __{unlhd}
+  - '"P{unlhd}"'
   asciimath:
-  - __{trianglelefteq}
-  - __{unlhd}
+  - '"P{trianglelefteq}"'
+  - '"P{unlhd}"'
   mathml:
   - "&#x22b4;"
   latex:
@@ -16608,10 +16607,10 @@
   - "&#x22b4;"
 - unicodemath:
   - trianglerighteq
-  - __{unrhd}
+  - '"P{unrhd}"'
   asciimath:
-  - __{trianglerighteq}
-  - __{unrhd}
+  - '"P{trianglerighteq}"'
+  - '"P{unrhd}"'
   mathml:
   - "&#x22b5;"
   latex:
@@ -16622,9 +16621,9 @@
   html:
   - "&#x22b5;"
 - unicodemath:
-  - __{upAlpha}
+  - '"P{upAlpha}"'
   asciimath:
-  - __{upAlpha}
+  - '"P{upAlpha}"'
   mathml:
   - "&#x391;"
   latex:
@@ -16634,11 +16633,11 @@
   html:
   - "&#x391;"
 - unicodemath:
-  - __{invamp}
-  - __{upand}
+  - '"P{invamp}"'
+  - '"P{upand}"'
   asciimath:
-  - __{invamp}
-  - __{upand}
+  - '"P{invamp}"'
+  - '"P{upand}"'
   mathml:
   - "&#x214b;"
   latex:
@@ -16651,7 +16650,7 @@
 - unicodemath:
   - Uparrow
   asciimath:
-  - __{Uparrow}
+  - '"P{Uparrow}"'
   mathml:
   - "&#x21d1;"
   latex:
@@ -16661,9 +16660,9 @@
   html:
   - "&#x21d1;"
 - unicodemath:
-  - __{uparrowbarred}
+  - '"P{uparrowbarred}"'
   asciimath:
-  - __{uparrowbarred}
+  - '"P{uparrowbarred}"'
   mathml:
   - "&#x2909;"
   latex:
@@ -16673,9 +16672,9 @@
   html:
   - "&#x2909;"
 - unicodemath:
-  - __{uparrowoncircle}
+  - '"P{uparrowoncircle}"'
   asciimath:
-  - __{uparrowoncircle}
+  - '"P{uparrowoncircle}"'
   mathml:
   - "&#x29bd;"
   latex:
@@ -16685,11 +16684,11 @@
   html:
   - "&#x29bd;"
 - unicodemath:
-  - __{beta}
-  - __{upbeta}
+  - '"P{beta}"'
+  - '"P{upbeta}"'
   asciimath:
   - beta
-  - __{upbeta}
+  - '"P{upbeta}"'
   mathml:
   - "&#x3b2;"
   latex:
@@ -16702,7 +16701,7 @@
 - unicodemath:
   - Cap
   asciimath:
-  - __{Cap}
+  - '"P{Cap}"'
   mathml:
   - "&#x22d2;"
   latex:
@@ -16714,11 +16713,11 @@
 - unicodemath:
   - Dd
   asciimath:
-  - __{Dd}
+  - '"P{Dd}"'
   mathml:
   - "&#x2145;"
   latex:
-  - __{Dd}
+  - "\\text{P[Dd]}"
   omml:
   - "&#x2145;"
   html:
@@ -16736,9 +16735,9 @@
   html:
   - "&#x394;"
 - unicodemath:
-  - __{UpcaseEquiv}
+  - '"P{UpcaseEquiv}"'
   asciimath:
-  - __{UpcaseEquiv}
+  - '"P{UpcaseEquiv}"'
   mathml:
   - "&#x2263;"
   latex:
@@ -16749,10 +16748,10 @@
   - "&#x2263;"
 - unicodemath:
   - Gamma
-  - __{upGamma}
+  - '"P{upGamma}"'
   asciimath:
   - Gamma
-  - __{upGamma}
+  - '"P{upGamma}"'
   mathml:
   - "&#x393;"
   latex:
@@ -16764,10 +16763,10 @@
   - "&#x393;"
 - unicodemath:
   - Lambda
-  - __{upLambda}
+  - '"P{upLambda}"'
   asciimath:
   - Lambda
-  - __{upLambda}
+  - '"P{upLambda}"'
   mathml:
   - "&#x39b;"
   latex:
@@ -16778,9 +16777,9 @@
   html:
   - "&#x39b;"
 - unicodemath:
-  - __{UpcaseMapsto}
+  - '"P{UpcaseMapsto}"'
   asciimath:
-  - __{UpcaseMapsto}
+  - '"P{UpcaseMapsto}"'
   mathml:
   - "&#x2907;"
   latex:
@@ -16790,11 +16789,11 @@
   html:
   - "&#x2907;"
 - unicodemath:
-  - __{UpcaseOmega}
-  - __{UpcaseupOmega}
+  - '"P{UpcaseOmega}"'
+  - '"P{UpcaseupOmega}"'
   asciimath:
   - Omega
-  - __{upOmega}
+  - '"P{upOmega}"'
   mathml:
   - "&#x3a9;"
   latex:
@@ -16806,10 +16805,10 @@
   - "&#x3a9;"
 - unicodemath:
   - Phi
-  - __{upPhi}
+  - '"P{upPhi}"'
   asciimath:
   - Phi
-  - __{upPhi}
+  - '"P{upPhi}"'
   mathml:
   - "&#x3a6;"
   latex:
@@ -16821,10 +16820,10 @@
   - "&#x3a6;"
 - unicodemath:
   - Pi
-  - __{upPi}
+  - '"P{upPi}"'
   asciimath:
   - Pi
-  - __{upPi}
+  - '"P{upPi}"'
   mathml:
   - "&#x3a0;"
   latex:
@@ -16836,10 +16835,10 @@
   - "&#x3a0;"
 - unicodemath:
   - Psi
-  - __{upPsi}
+  - '"P{upPsi}"'
   asciimath:
   - Psi
-  - __{upPsi}
+  - '"P{upPsi}"'
   mathml:
   - "&#x3a8;"
   latex:
@@ -16850,13 +16849,13 @@
   html:
   - "&#x3a8;"
 - unicodemath:
-  - __{rrbracket}
-  - __{rBrack}
-  - __{UpcaseRbrack}
+  - '"P{rrbracket}"'
+  - '"P{rBrack}"'
+  - '"P{UpcaseRbrack}"'
   asciimath:
-  - __{rrbracket}
-  - __{rBrack}
-  - __{UpcaseRbrack}
+  - '"P{rrbracket}"'
+  - '"P{rBrack}"'
+  - '"P{UpcaseRbrack}"'
   mathml:
   - "&#x27e7;"
   latex:
@@ -16869,33 +16868,33 @@
   - "&#x27e7;"
 - unicodemath:
   - Rightarrow
-  - __{implies}
-  - __{rArr}
-  - __{=>}
-  - __{UpcaseRightarrow}
+  - '"P{implies}"'
+  - '"P{rArr}"'
+  - '"P{=>}"'
+  - '"P{UpcaseRightarrow}"'
   asciimath:
   - Rightarrow
   - implies
   - rArr
   - "=>"
-  - __{UpcaseRightarrow}
+  - '"P{UpcaseRightarrow}"'
   mathml:
   - "&#x21d2;"
   latex:
   - Rightarrow
-  - __{implies}
-  - __{rArr}
-  - __{=>}
+  - "\\text{P[implies]}"
+  - "\\text{P[rArr]}"
+  - "\\text{P[=>]}"
   omml:
   - "&#x21d2;"
   html:
   - "&#x21d2;"
 - unicodemath:
   - Sigma
-  - __{upSigma}
+  - '"P{upSigma}"'
   asciimath:
   - Sigma
-  - __{upSigma}
+  - '"P{upSigma}"'
   mathml:
   - "&#x3a3;"
   latex:
@@ -16907,10 +16906,10 @@
   - "&#x3a3;"
 - unicodemath:
   - Theta
-  - __{upTheta}
+  - '"P{upTheta}"'
   asciimath:
   - Theta
-  - __{upTheta}
+  - '"P{upTheta}"'
   mathml:
   - "&#x398;"
   latex:
@@ -16921,9 +16920,9 @@
   html:
   - "&#x398;"
 - unicodemath:
-  - __{UpcaseWedge}
+  - '"P{UpcaseWedge}"'
   asciimath:
-  - __{UpcaseWedge}
+  - '"P{UpcaseWedge}"'
   mathml:
   - "&#x2a53;"
   latex:
@@ -16934,10 +16933,10 @@
   - "&#x2a53;"
 - unicodemath:
   - Xi
-  - __{upXi}
+  - '"P{upXi}"'
   asciimath:
   - Xi
-  - __{upXi}
+  - '"P{upXi}"'
   mathml:
   - "&#x39e;"
   latex:
@@ -16948,11 +16947,11 @@
   html:
   - "&#x39e;"
 - unicodemath:
-  - __{UpcaseOmega}
-  - __{UpcaseupOmega}
+  - '"P{UpcaseOmega}"'
+  - '"P{UpcaseupOmega}"'
   asciimath:
   - Omega
-  - __{upOmega}
+  - '"P{upOmega}"'
   mathml:
   - "&#x3a9;"
   latex:
@@ -16963,9 +16962,9 @@
   html:
   - "&#x3a9;"
 - unicodemath:
-  - __{upChi}
+  - '"P{upChi}"'
   asciimath:
-  - __{upChi}
+  - '"P{upChi}"'
   mathml:
   - "&#x3a7;"
   latex:
@@ -16975,9 +16974,9 @@
   html:
   - "&#x3a7;"
 - unicodemath:
-  - __{updasharrow}
+  - '"P{updasharrow}"'
   asciimath:
-  - __{updasharrow}
+  - '"P{updasharrow}"'
   mathml:
   - "&#x21e1;"
   latex:
@@ -16989,7 +16988,7 @@
 - unicodemath:
   - Updownarrow
   asciimath:
-  - __{Updownarrow}
+  - '"P{Updownarrow}"'
   mathml:
   - "&#x21d5;"
   latex:
@@ -16999,9 +16998,9 @@
   html:
   - "&#x21d5;"
 - unicodemath:
-  - __{updownarrowbar}
+  - '"P{updownarrowbar}"'
   asciimath:
-  - __{updownarrowbar}
+  - '"P{updownarrowbar}"'
   mathml:
   - "&#x21a8;"
   latex:
@@ -17012,10 +17011,10 @@
   - "&#x21a8;"
 - unicodemath:
   - updownarrows
-  - __{uparrowdownarrow}
+  - '"P{uparrowdownarrow}"'
   asciimath:
-  - __{updownarrows}
-  - __{uparrowdownarrow}
+  - '"P{updownarrows}"'
+  - '"P{uparrowdownarrow}"'
   mathml:
   - "&#x21c5;"
   latex:
@@ -17026,9 +17025,9 @@
   html:
   - "&#x21c5;"
 - unicodemath:
-  - __{updownharpoonleftright}
+  - '"P{updownharpoonleftright}"'
   asciimath:
-  - __{updownharpoonleftright}
+  - '"P{updownharpoonleftright}"'
   mathml:
   - "&#x294d;"
   latex:
@@ -17038,9 +17037,9 @@
   html:
   - "&#x294d;"
 - unicodemath:
-  - __{updownharpoonrightleft}
+  - '"P{updownharpoonrightleft}"'
   asciimath:
-  - __{updownharpoonrightleft}
+  - '"P{updownharpoonrightleft}"'
   mathml:
   - "&#x294c;"
   latex:
@@ -17050,9 +17049,9 @@
   html:
   - "&#x294c;"
 - unicodemath:
-  - __{upEpsilon}
+  - '"P{upEpsilon}"'
   asciimath:
-  - __{upEpsilon}
+  - '"P{upEpsilon}"'
   mathml:
   - "&#x395;"
   latex:
@@ -17062,13 +17061,13 @@
   html:
   - "&#x395;"
 - unicodemath:
-  - __{updownharpoonsleftright}
-  - __{updownharpoons}
-  - __{upequilibrium}
+  - '"P{updownharpoonsleftright}"'
+  - '"P{updownharpoons}"'
+  - '"P{upequilibrium}"'
   asciimath:
-  - __{updownharpoonsleftright}
-  - __{updownharpoons}
-  - __{upequilibrium}
+  - '"P{updownharpoonsleftright}"'
+  - '"P{updownharpoons}"'
+  - '"P{upequilibrium}"'
   mathml:
   - "&#x296e;"
   latex:
@@ -17080,9 +17079,9 @@
   html:
   - "&#x296e;"
 - unicodemath:
-  - __{upEta}
+  - '"P{upEta}"'
   asciimath:
-  - __{upEta}
+  - '"P{upEta}"'
   mathml:
   - "&#x397;"
   latex:
@@ -17092,9 +17091,9 @@
   html:
   - "&#x397;"
 - unicodemath:
-  - __{upfishtail}
+  - '"P{upfishtail}"'
   asciimath:
-  - __{upfishtail}
+  - '"P{upfishtail}"'
   mathml:
   - "&#x297e;"
   latex:
@@ -17105,10 +17104,10 @@
   - "&#x297e;"
 - unicodemath:
   - upharpoonleft
-  - __{upharpoonleftup}
+  - '"P{upharpoonleftup}"'
   asciimath:
-  - __{upharpoonleft}
-  - __{upharpoonleftup}
+  - '"P{upharpoonleft}"'
+  - '"P{upharpoonleftup}"'
   mathml:
   - "&#x21bf;"
   latex:
@@ -17119,9 +17118,9 @@
   html:
   - "&#x21bf;"
 - unicodemath:
-  - __{upin}
+  - '"P{upin}"'
   asciimath:
-  - __{upin}
+  - '"P{upin}"'
   mathml:
   - "&#x27d2;"
   latex:
@@ -17131,9 +17130,9 @@
   html:
   - "&#x27d2;"
 - unicodemath:
-  - __{upint}
+  - '"P{upint}"'
   asciimath:
-  - __{upint}
+  - '"P{upint}"'
   mathml:
   - "&#x2a1b;"
   latex:
@@ -17143,9 +17142,9 @@
   html:
   - "&#x2a1b;"
 - unicodemath:
-  - __{upIota}
+  - '"P{upIota}"'
   asciimath:
-  - __{upIota}
+  - '"P{upIota}"'
   mathml:
   - "&#x399;"
   latex:
@@ -17155,9 +17154,9 @@
   html:
   - "&#x399;"
 - unicodemath:
-  - __{upKappa}
+  - '"P{upKappa}"'
   asciimath:
-  - __{upKappa}
+  - '"P{upKappa}"'
   mathml:
   - "&#x39a;"
   latex:
@@ -17167,9 +17166,9 @@
   html:
   - "&#x39a;"
 - unicodemath:
-  - __{upkoppa}
+  - '"P{upkoppa}"'
   asciimath:
-  - __{upkoppa}
+  - '"P{upkoppa}"'
   mathml:
   - "&#x3df;"
   latex:
@@ -17179,9 +17178,9 @@
   html:
   - "&#x3df;"
 - unicodemath:
-  - __{upMu}
+  - '"P{upMu}"'
   asciimath:
-  - __{upMu}
+  - '"P{upMu}"'
   mathml:
   - "&#x39c;"
   latex:
@@ -17191,9 +17190,9 @@
   html:
   - "&#x39c;"
 - unicodemath:
-  - __{upNu}
+  - '"P{upNu}"'
   asciimath:
-  - __{upNu}
+  - '"P{upNu}"'
   mathml:
   - "&#x39d;"
   latex:
@@ -17203,9 +17202,9 @@
   html:
   - "&#x39d;"
 - unicodemath:
-  - __{upomicron}
+  - '"P{upomicron}"'
   asciimath:
-  - __{upomicron}
+  - '"P{upomicron}"'
   mathml:
   - "&#x3bf;"
   latex:
@@ -17215,9 +17214,9 @@
   html:
   - "&#x3bf;"
 - unicodemath:
-  - __{upRho}
+  - '"P{upRho}"'
   asciimath:
-  - __{upRho}
+  - '"P{upRho}"'
   mathml:
   - "&#x3a1;"
   latex:
@@ -17227,9 +17226,9 @@
   html:
   - "&#x3a1;"
 - unicodemath:
-  - __{uprightcurvearrow}
+  - '"P{uprightcurvearrow}"'
   asciimath:
-  - __{uprightcurvearrow}
+  - '"P{uprightcurvearrow}"'
   mathml:
   - "&#x2934;"
   latex:
@@ -17240,10 +17239,10 @@
   - "&#x2934;"
 - unicodemath:
   - upsilon
-  - __{upupsilon}
+  - '"P{upupsilon}"'
   asciimath:
   - upsilon
-  - __{upupsilon}
+  - '"P{upupsilon}"'
   mathml:
   - "&#x3c5;"
   latex:
@@ -17254,9 +17253,9 @@
   html:
   - "&#x3c5;"
 - unicodemath:
-  - __{upTau}
+  - '"P{upTau}"'
   asciimath:
-  - __{upTau}
+  - '"P{upTau}"'
   mathml:
   - "&#x3a4;"
   latex:
@@ -17268,7 +17267,7 @@
 - unicodemath:
   - upuparrows
   asciimath:
-  - __{upuparrows}
+  - '"P{upuparrows}"'
   mathml:
   - "&#x21c8;"
   latex:
@@ -17278,11 +17277,11 @@
   html:
   - "&#x21c8;"
 - unicodemath:
-  - __{upharpoonsleftright}
-  - __{upupharpoons}
+  - '"P{upharpoonsleftright}"'
+  - '"P{upupharpoons}"'
   asciimath:
-  - __{upharpoonsleftright}
-  - __{upupharpoons}
+  - '"P{upharpoonsleftright}"'
+  - '"P{upupharpoons}"'
   mathml:
   - "&#x2963;"
   latex:
@@ -17294,10 +17293,10 @@
   - "&#x2963;"
 - unicodemath:
   - varsigma
-  - __{upvarsigma}
+  - '"P{upvarsigma}"'
   asciimath:
-  - __{varsigma}
-  - __{upvarsigma}
+  - '"P{varsigma}"'
+  - '"P{upvarsigma}"'
   mathml:
   - "&#x3c2;"
   latex:
@@ -17308,9 +17307,9 @@
   html:
   - "&#x3c2;"
 - unicodemath:
-  - __{upvarTheta}
+  - '"P{upvarTheta}"'
   asciimath:
-  - __{upvarTheta}
+  - '"P{upvarTheta}"'
   mathml:
   - "&#x3f4;"
   latex:
@@ -17320,9 +17319,9 @@
   html:
   - "&#x3f4;"
 - unicodemath:
-  - __{upwhitearrow}
+  - '"P{upwhitearrow}"'
   asciimath:
-  - __{upwhitearrow}
+  - '"P{upwhitearrow}"'
   mathml:
   - "&#x21e7;"
   latex:
@@ -17332,9 +17331,9 @@
   html:
   - "&#x21e7;"
 - unicodemath:
-  - __{upZeta}
+  - '"P{upZeta}"'
   asciimath:
-  - __{upZeta}
+  - '"P{upZeta}"'
   mathml:
   - "&#x396;"
   latex:
@@ -17344,11 +17343,11 @@
   html:
   - "&#x396;"
 - unicodemath:
-  - __{uranus}
-  - __{Uranus}
+  - '"P{uranus}"'
+  - '"P{Uranus}"'
   asciimath:
-  - __{uranus}
-  - __{Uranus}
+  - '"P{uranus}"'
+  - '"P{Uranus}"'
   mathml:
   - "&#x2645;"
   latex:
@@ -17359,9 +17358,9 @@
   html:
   - "&#x2645;"
 - unicodemath:
-  - __{urarc}
+  - '"P{urarc}"'
   asciimath:
-  - __{urarc}
+  - '"P{urarc}"'
   mathml:
   - "&#x25dd;"
   latex:
@@ -17371,9 +17370,9 @@
   html:
   - "&#x25dd;"
 - unicodemath:
-  - __{urblacktriangle}
+  - '"P{urblacktriangle}"'
   asciimath:
-  - __{urblacktriangle}
+  - '"P{urblacktriangle}"'
   mathml:
   - "&#x25e5;"
   latex:
@@ -17383,9 +17382,9 @@
   html:
   - "&#x25e5;"
 - unicodemath:
-  - __{urcorner}
+  - '"P{urcorner}"'
   asciimath:
-  - __{urcorner}
+  - '"P{urcorner}"'
   mathml:
   - "&#x231d;"
   latex:
@@ -17395,9 +17394,9 @@
   html:
   - "&#x231d;"
 - unicodemath:
-  - __{urtriangle}
+  - '"P{urtriangle}"'
   asciimath:
-  - __{urtriangle}
+  - '"P{urtriangle}"'
   mathml:
   - "&#x25f9;"
   latex:
@@ -17407,11 +17406,11 @@
   html:
   - "&#x25f9;"
 - unicodemath:
-  - __{wideutilde}
-  - __{utilde}
+  - '"P{wideutilde}"'
+  - '"P{utilde}"'
   asciimath:
-  - __{wideutilde}
-  - __{utilde}
+  - '"P{wideutilde}"'
+  - '"P{utilde}"'
   mathml:
   - "&#x330;"
   latex:
@@ -17423,7 +17422,7 @@
   - "&#x330;"
 - unicodemath:
   - cup
-  - __{uu}
+  - '"P{uu}"'
   asciimath:
   - cup
   - uu
@@ -17431,15 +17430,15 @@
   - "&#x222a;"
   latex:
   - cup
-  - __{uu}
+  - "\\text{P[uu]}"
   omml:
   - "&#x222a;"
   html:
   - "&#x222a;"
 - unicodemath:
-  - __{Uuparrow}
+  - '"P{Uuparrow}"'
   asciimath:
-  - __{Uuparrow}
+  - '"P{Uuparrow}"'
   mathml:
   - "&#x290a;"
   latex:
@@ -17449,27 +17448,27 @@
   html:
   - "&#x290a;"
 - unicodemath:
-  - bigcup
-  - __{uuu}
-  - __{duni}
+  - '"P{bigcup}"'
+  - '"P{uuu}"'
+  - '"P{duni}"'
   asciimath:
   - bigcup
   - uuu
-  - __{duni}
+  - '"P{duni}"'
   mathml:
   - "&#x22c3;"
   latex:
   - bigcup
   - duni
-  - __{uuu}
+  - "\\text{P[uuu]}"
   omml:
   - "&#x22c3;"
   html:
   - "&#x22c3;"
 - unicodemath:
-  - __{varbarwedge}
+  - '"P{varbarwedge}"'
   asciimath:
-  - __{varbarwedge}
+  - '"P{varbarwedge}"'
   mathml:
   - "&#x2305;"
   latex:
@@ -17479,11 +17478,11 @@
   html:
   - "&#x2305;"
 - unicodemath:
-  - __{upvarbeta}
-  - __{varbeta}
+  - '"P{upvarbeta}"'
+  - '"P{varbeta}"'
   asciimath:
-  - __{upvarbeta}
-  - __{varbeta}
+  - '"P{upvarbeta}"'
+  - '"P{varbeta}"'
   mathml:
   - "&#x3d0;"
   latex:
@@ -17494,9 +17493,9 @@
   html:
   - "&#x3d0;"
 - unicodemath:
-  - __{varcarriagereturn}
+  - '"P{varcarriagereturn}"'
   asciimath:
-  - __{varcarriagereturn}
+  - '"P{varcarriagereturn}"'
   mathml:
   - "&#x23ce;"
   latex:
@@ -17506,11 +17505,11 @@
   html:
   - "&#x23ce;"
 - unicodemath:
-  - __{varclubsuit}
-  - __{varclub}
+  - '"P{varclubsuit}"'
+  - '"P{varclub}"'
   asciimath:
-  - __{varclubsuit}
-  - __{varclub}
+  - '"P{varclubsuit}"'
+  - '"P{varclub}"'
   mathml:
   - "&#x2667;"
   latex:
@@ -17521,11 +17520,11 @@
   html:
   - "&#x2667;"
 - unicodemath:
-  - __{vardiamondsuit}
-  - __{vardiamond}
+  - '"P{vardiamondsuit}"'
+  - '"P{vardiamond}"'
   asciimath:
-  - __{vardiamondsuit}
-  - __{vardiamond}
+  - '"P{vardiamondsuit}"'
+  - '"P{vardiamond}"'
   mathml:
   - "&#x2666;"
   latex:
@@ -17536,9 +17535,9 @@
   html:
   - "&#x2666;"
 - unicodemath:
-  - __{vardoublebarwedge}
+  - '"P{vardoublebarwedge}"'
   asciimath:
-  - __{vardoublebarwedge}
+  - '"P{vardoublebarwedge}"'
   mathml:
   - "&#x2306;"
   latex:
@@ -17560,11 +17559,11 @@
   html:
   - "&#x25b;"
 - unicodemath:
-  - __{varheartsuit}
-  - __{varheart}
+  - '"P{varheartsuit}"'
+  - '"P{varheart}"'
   asciimath:
-  - __{varheartsuit}
-  - __{varheart}
+  - '"P{varheartsuit}"'
+  - '"P{varheart}"'
   mathml:
   - "&#x2665;"
   latex:
@@ -17575,9 +17574,9 @@
   html:
   - "&#x2665;"
 - unicodemath:
-  - __{varhexagon}
+  - '"P{varhexagon}"'
   asciimath:
-  - __{varhexagon}
+  - '"P{varhexagon}"'
   mathml:
   - "&#x2b21;"
   latex:
@@ -17587,9 +17586,9 @@
   html:
   - "&#x2b21;"
 - unicodemath:
-  - __{varhexagonblack}
+  - '"P{varhexagonblack}"'
   asciimath:
-  - __{varhexagonblack}
+  - '"P{varhexagonblack}"'
   mathml:
   - "&#x2b22;"
   latex:
@@ -17599,9 +17598,9 @@
   html:
   - "&#x2b22;"
 - unicodemath:
-  - __{varhexagonlrbonds}
+  - '"P{varhexagonlrbonds}"'
   asciimath:
-  - __{varhexagonlrbonds}
+  - '"P{varhexagonlrbonds}"'
   mathml:
   - "&#x232c;"
   latex:
@@ -17611,9 +17610,9 @@
   html:
   - "&#x232c;"
 - unicodemath:
-  - __{varisins}
+  - '"P{varisins}"'
   asciimath:
-  - __{varisins}
+  - '"P{varisins}"'
   mathml:
   - "&#x22f3;"
   latex:
@@ -17624,10 +17623,10 @@
   - "&#x22f3;"
 - unicodemath:
   - varkappa
-  - __{upvarkappa}
+  - '"P{upvarkappa}"'
   asciimath:
-  - __{varkappa}
-  - __{upvarkappa}
+  - '"P{varkappa}"'
+  - '"P{upvarkappa}"'
   mathml:
   - "&#x3f0;"
   latex:
@@ -17638,9 +17637,9 @@
   html:
   - "&#x3f0;"
 - unicodemath:
-  - __{varlrtriangle}
+  - '"P{varlrtriangle}"'
   asciimath:
-  - __{varlrtriangle}
+  - '"P{varlrtriangle}"'
   mathml:
   - "&#x22bf;"
   latex:
@@ -17650,9 +17649,9 @@
   html:
   - "&#x22bf;"
 - unicodemath:
-  - __{varniobar}
+  - '"P{varniobar}"'
   asciimath:
-  - __{varniobar}
+  - '"P{varniobar}"'
   mathml:
   - "&#x22fd;"
   latex:
@@ -17662,9 +17661,9 @@
   html:
   - "&#x22fd;"
 - unicodemath:
-  - __{varnis}
+  - '"P{varnis}"'
   asciimath:
-  - __{varnis}
+  - '"P{varnis}"'
   mathml:
   - "&#x22fb;"
   latex:
@@ -17675,28 +17674,28 @@
   - "&#x22fb;"
 - unicodemath:
   - emptyset
-  - __{O/}
-  - __{varnothing}
+  - '"P{O/}"'
+  - '"P{varnothing}"'
   asciimath:
   - emptyset
   - O/
-  - __{varnothing}
+  - '"P{varnothing}"'
   mathml:
   - "&#x2205;"
   latex:
   - varnothing
   - emptyset
-  - __{O/}
+  - "\\text{P[O/]}"
   omml:
   - "&#x2205;"
   html:
   - "&#x2205;"
 - unicodemath:
   - phi
-  - __{upphi}
+  - '"P{upphi}"'
   asciimath:
   - phi
-  - __{upphi}
+  - '"P{upphi}"'
   mathml:
   - "&#x3d5;"
   latex:
@@ -17708,10 +17707,10 @@
   - "&#x3d5;"
 - unicodemath:
   - varpi
-  - __{upvarpi}
+  - '"P{upvarpi}"'
   asciimath:
-  - __{varpi}
-  - __{upvarpi}
+  - '"P{varpi}"'
+  - '"P{upvarpi}"'
   mathml:
   - "&#x3d6;"
   latex:
@@ -17722,11 +17721,11 @@
   html:
   - "&#x3d6;"
 - unicodemath:
-  - __{bigtimes}
-  - __{varprod}
+  - '"P{bigtimes}"'
+  - '"P{varprod}"'
   asciimath:
-  - __{bigtimes}
-  - __{varprod}
+  - '"P{bigtimes}"'
+  - '"P{varprod}"'
   mathml:
   - "&#x2a09;"
   latex:
@@ -17738,10 +17737,10 @@
   - "&#x2a09;"
 - unicodemath:
   - varrho
-  - __{upvarrho}
+  - '"P{upvarrho}"'
   asciimath:
-  - __{varrho}
-  - __{upvarrho}
+  - '"P{varrho}"'
+  - '"P{upvarrho}"'
   mathml:
   - "&#x3f1;"
   latex:
@@ -17753,10 +17752,10 @@
   - "&#x3f1;"
 - unicodemath:
   - varsigma
-  - __{upvarsigma}
+  - '"P{upvarsigma}"'
   asciimath:
-  - __{varsigma}
-  - __{upvarsigma}
+  - '"P{varsigma}"'
+  - '"P{upvarsigma}"'
   mathml:
   - "&#x3c2;"
   latex:
@@ -17768,26 +17767,26 @@
   - "&#x3c2;"
 - unicodemath:
   - diamondsuit
-  - __{varspadesuit}
-  - __{varspade}
+  - '"P{varspadesuit}"'
+  - '"P{varspade}"'
   asciimath:
-  - __{diamondsuit}
-  - __{varspadesuit}
-  - __{varspade}
+  - '"P{diamondsuit}"'
+  - '"P{varspadesuit}"'
+  - '"P{varspade}"'
   mathml:
   - "&#x2664;"
   latex:
   - varspadesuit
   - varspade
-  - __{diamondsuit}
+  - "\\text{P[diamondsuit]}"
   omml:
   - "&#x2664;"
   html:
   - "&#x2664;"
 - unicodemath:
-  - __{varstar}
+  - '"P{varstar}"'
   asciimath:
-  - __{varstar}
+  - '"P{varstar}"'
   mathml:
   - "&#x2736;"
   latex:
@@ -17798,10 +17797,10 @@
   - "&#x2736;"
 - unicodemath:
   - vartheta
-  - __{upvartheta}
+  - '"P{upvartheta}"'
   asciimath:
   - vartheta
-  - __{upvartheta}
+  - '"P{upvartheta}"'
   mathml:
   - "&#x3d1;"
   latex:
@@ -17812,11 +17811,11 @@
   html:
   - "&#x3d1;"
 - unicodemath:
-  - __{smalltriangleup}
-  - __{vartriangle}
+  - '"P{smalltriangleup}"'
+  - '"P{vartriangle}"'
   asciimath:
-  - __{smalltriangleup}
-  - __{vartriangle}
+  - '"P{smalltriangleup}"'
+  - '"P{vartriangle}"'
   mathml:
   - "&#x25b5;"
   latex:
@@ -17829,7 +17828,7 @@
 - unicodemath:
   - vartriangleleft
   asciimath:
-  - __{vartriangleleft}
+  - '"P{vartriangleleft}"'
   mathml:
   - "&#x22b2;"
   latex:
@@ -17841,7 +17840,7 @@
 - unicodemath:
   - vartriangleright
   asciimath:
-  - __{vartriangleright}
+  - '"P{vartriangleright}"'
   mathml:
   - "&#x22b3;"
   latex:
@@ -17851,9 +17850,9 @@
   html:
   - "&#x22b3;"
 - unicodemath:
-  - __{varVdash}
+  - '"P{varVdash}"'
   asciimath:
-  - __{varVdash}
+  - '"P{varVdash}"'
   mathml:
   - "&#x2ae6;"
   latex:
@@ -17863,9 +17862,9 @@
   html:
   - "&#x2ae6;"
 - unicodemath:
-  - __{varveebar}
+  - '"P{varveebar}"'
   asciimath:
-  - __{varveebar}
+  - '"P{varveebar}"'
   mathml:
   - "&#x2a61;"
   latex:
@@ -17877,19 +17876,19 @@
 - unicodemath:
   - vbar
   asciimath:
-  - __{vbar}
+  - '"P{vbar}"'
   mathml:
   - "&#x2502;"
   latex:
-  - __{vbar}
+  - "\\text{P[vbar]}"
   omml:
   - "&#x2502;"
   html:
   - "&#x2502;"
 - unicodemath:
-  - __{vBarv}
+  - '"P{vBarv}"'
   asciimath:
-  - __{vBarv}
+  - '"P{vBarv}"'
   mathml:
   - "&#x2ae9;"
   latex:
@@ -17899,9 +17898,9 @@
   html:
   - "&#x2ae9;"
 - unicodemath:
-  - __{vbraceextender}
+  - '"P{vbraceextender}"'
   asciimath:
-  - __{vbraceextender}
+  - '"P{vbraceextender}"'
   mathml:
   - "&#x23aa;"
   latex:
@@ -17911,11 +17910,11 @@
   html:
   - "&#x23aa;"
 - unicodemath:
-  - __{RightTriangleBar}
-  - __{vbrtri}
+  - '"P{RightTriangleBar}"'
+  - '"P{vbrtri}"'
   asciimath:
-  - __{RightTriangleBar}
-  - __{vbrtri}
+  - '"P{RightTriangleBar}"'
+  - '"P{vbrtri}"'
   mathml:
   - "&#x29d0;"
   latex:
@@ -17927,7 +17926,7 @@
   - "&#x29d0;"
 - unicodemath:
   - vdash
-  - __{|--}
+  - '"P{|--}"'
   asciimath:
   - vdash
   - "|--"
@@ -17935,15 +17934,15 @@
   - "&#x22a2;"
   latex:
   - vdash
-  - __{|--}
+  - "\\text{P[|--]}"
   omml:
   - "&#x22a2;"
   html:
   - "&#x22a2;"
 - unicodemath:
-  - __{vDdash}
+  - '"P{vDdash}"'
   asciimath:
-  - __{vDdash}
+  - '"P{vDdash}"'
   mathml:
   - "&#x2ae2;"
   latex:
@@ -17965,9 +17964,9 @@
   html:
   - "&#x22ee;"
 - unicodemath:
-  - __{Vec}
+  - '"P{Vec}"'
   asciimath:
-  - __{Vec}
+  - '"P{Vec}"'
   mathml:
   - "&#x20d7;"
   latex:
@@ -17977,9 +17976,9 @@
   html:
   - "&#x20d7;"
 - unicodemath:
-  - __{vectimes}
+  - '"P{vectimes}"'
   asciimath:
-  - __{vectimes}
+  - '"P{vectimes}"'
   mathml:
   - "&#x2a2f;"
   latex:
@@ -17989,9 +17988,9 @@
   html:
   - "&#x2a2f;"
 - unicodemath:
-  - __{Vee}
+  - '"P{Vee}"'
   asciimath:
-  - __{Vee}
+  - '"P{Vee}"'
   mathml:
   - "&#x2a54;"
   latex:
@@ -18001,9 +18000,9 @@
   html:
   - "&#x2a54;"
 - unicodemath:
-  - __{veebar}
+  - '"P{veebar}"'
   asciimath:
-  - __{veebar}
+  - '"P{veebar}"'
   mathml:
   - "&#x22bb;"
   latex:
@@ -18013,9 +18012,9 @@
   html:
   - "&#x22bb;"
 - unicodemath:
-  - __{veedot}
+  - '"P{veedot}"'
   asciimath:
-  - __{veedot}
+  - '"P{veedot}"'
   mathml:
   - "&#x27c7;"
   latex:
@@ -18025,9 +18024,9 @@
   html:
   - "&#x27c7;"
 - unicodemath:
-  - __{veedoublebar}
+  - '"P{veedoublebar}"'
   asciimath:
-  - __{veedoublebar}
+  - '"P{veedoublebar}"'
   mathml:
   - "&#x2a63;"
   latex:
@@ -18037,9 +18036,9 @@
   html:
   - "&#x2a63;"
 - unicodemath:
-  - __{veeeq}
+  - '"P{veeeq}"'
   asciimath:
-  - __{veeeq}
+  - '"P{veeeq}"'
   mathml:
   - "&#x225a;"
   latex:
@@ -18049,9 +18048,9 @@
   html:
   - "&#x225a;"
 - unicodemath:
-  - __{veemidvert}
+  - '"P{veemidvert}"'
   asciimath:
-  - __{veemidvert}
+  - '"P{veemidvert}"'
   mathml:
   - "&#x2a5b;"
   latex:
@@ -18061,9 +18060,9 @@
   html:
   - "&#x2a5b;"
 - unicodemath:
-  - __{veeodot}
+  - '"P{veeodot}"'
   asciimath:
-  - __{veeodot}
+  - '"P{veeodot}"'
   mathml:
   - "&#x2a52;"
   latex:
@@ -18073,9 +18072,9 @@
   html:
   - "&#x2a52;"
 - unicodemath:
-  - __{veeonvee}
+  - '"P{veeonvee}"'
   asciimath:
-  - __{veeonvee}
+  - '"P{veeonvee}"'
   mathml:
   - "&#x2a56;"
   latex:
@@ -18085,9 +18084,9 @@
   html:
   - "&#x2a56;"
 - unicodemath:
-  - __{veeonwedge}
+  - '"P{veeonwedge}"'
   asciimath:
-  - __{veeonwedge}
+  - '"P{veeonwedge}"'
   mathml:
   - "&#x2a59;"
   latex:
@@ -18097,11 +18096,11 @@
   html:
   - "&#x2a59;"
 - unicodemath:
-  - __{female}
-  - __{Venus}
+  - '"P{female}"'
+  - '"P{Venus}"'
   asciimath:
-  - __{female}
-  - __{Venus}
+  - '"P{female}"'
+  - '"P{Venus}"'
   mathml:
   - "&#x2640;"
   latex:
@@ -18112,9 +18111,9 @@
   html:
   - "&#x2640;"
 - unicodemath:
-  - __{vertoverlay}
+  - '"P{vertoverlay}"'
   asciimath:
-  - __{vertoverlay}
+  - '"P{vertoverlay}"'
   mathml:
   - "&#x20d2;"
   latex:
@@ -18124,9 +18123,9 @@
   html:
   - "&#x20d2;"
 - unicodemath:
-  - __{viewdata}
+  - '"P{viewdata}"'
   asciimath:
-  - __{viewdata}
+  - '"P{viewdata}"'
   mathml:
   - "&#x2317;"
   latex:
@@ -18136,9 +18135,9 @@
   html:
   - "&#x2317;"
 - unicodemath:
-  - __{virgo}
+  - '"P{virgo}"'
   asciimath:
-  - __{virgo}
+  - '"P{virgo}"'
   mathml:
   - "&#x264d;"
   latex:
@@ -18148,9 +18147,9 @@
   html:
   - "&#x264d;"
 - unicodemath:
-  - __{vlongdash}
+  - '"P{vlongdash}"'
   asciimath:
-  - __{vlongdash}
+  - '"P{vlongdash}"'
   mathml:
   - "&#x27dd;"
   latex:
@@ -18160,9 +18159,9 @@
   html:
   - "&#x27dd;"
 - unicodemath:
-  - __{vrectangle}
+  - '"P{vrectangle}"'
   asciimath:
-  - __{vrectangle}
+  - '"P{vrectangle}"'
   mathml:
   - "&#x25af;"
   latex:
@@ -18172,9 +18171,9 @@
   html:
   - "&#x25af;"
 - unicodemath:
-  - __{vrectangleblack}
+  - '"P{vrectangleblack}"'
   asciimath:
-  - __{vrectangleblack}
+  - '"P{vrectangleblack}"'
   mathml:
   - "&#x25ae;"
   latex:
@@ -18185,18 +18184,18 @@
   - "&#x25ae;"
 - unicodemath:
   - lor
-  - __{vee}
-  - __{vv}
+  - '"P{vee}"'
+  - '"P{vv}"'
   asciimath:
   - vee
   - vv
-  - __{lor}
+  - '"P{lor}"'
   mathml:
   - "&#x2228;"
   latex:
   - vee
   - lor
-  - __{vv}
+  - "\\text{P[vv]}"
   omml:
   - "&#x2228;"
   html:
@@ -18204,7 +18203,7 @@
 - unicodemath:
   - Vvdash
   asciimath:
-  - __{Vvdash}
+  - '"P{Vvdash}"'
   mathml:
   - "&#x22aa;"
   latex:
@@ -18214,8 +18213,8 @@
   html:
   - "&#x22aa;"
 - unicodemath:
-  - bigvee
-  - __{vvv}
+  - '"P{bigvee}"'
+  - '"P{vvv}"'
   asciimath:
   - bigvee
   - vvv
@@ -18223,30 +18222,30 @@
   - "&#x22c1;"
   latex:
   - bigvee
-  - __{vvv}
+  - "\\text{P[vvv]}"
   omml:
   - "&#x22c1;"
   html:
   - "&#x22c1;"
 - unicodemath:
   - bullet
-  - __{vysmblkcircle}
+  - '"P{vysmblkcircle}"'
   asciimath:
-  - __{bullet}
-  - __{vysmblkcircle}
+  - '"P{bullet}"'
+  - '"P{vysmblkcircle}"'
   mathml:
   - "&#x2219;"
   latex:
   - vysmblkcircle
-  - __{bullet}
+  - "\\text{P[bullet]}"
   omml:
   - "&#x2219;"
   html:
   - "&#x2219;"
 - unicodemath:
-  - __{vysmblksquare}
+  - '"P{vysmblksquare}"'
   asciimath:
-  - __{vysmblksquare}
+  - '"P{vysmblksquare}"'
   mathml:
   - "&#x2b1d;"
   latex:
@@ -18257,26 +18256,26 @@
   - "&#x2b1d;"
 - unicodemath:
   - circ
-  - __{@}
-  - __{vysmwhtcircle}
+  - '"P{@}"'
+  - '"P{vysmwhtcircle}"'
   asciimath:
   - circ
   - "@"
-  - __{vysmwhtcircle}
+  - '"P{vysmwhtcircle}"'
   mathml:
   - "&#x2218;"
   latex:
   - vysmwhtcircle
   - circ
-  - __{@}
+  - "\\text{P[@]}"
   omml:
   - "&#x2218;"
   html:
   - "&#x2218;"
 - unicodemath:
-  - __{vysmwhtsquare}
+  - '"P{vysmwhtsquare}"'
   asciimath:
-  - __{vysmwhtsquare}
+  - '"P{vysmwhtsquare}"'
   mathml:
   - "&#x2b1e;"
   latex:
@@ -18286,9 +18285,9 @@
   html:
   - "&#x2b1e;"
 - unicodemath:
-  - __{vzigzag}
+  - '"P{vzigzag}"'
   asciimath:
-  - __{vzigzag}
+  - '"P{vzigzag}"'
   mathml:
   - "&#x299a;"
   latex:
@@ -18298,9 +18297,9 @@
   html:
   - "&#x299a;"
 - unicodemath:
-  - __{warning}
+  - '"P{warning}"'
   asciimath:
-  - __{warning}
+  - '"P{warning}"'
   mathml:
   - "&#x26a0;"
   latex:
@@ -18311,44 +18310,44 @@
   - "&#x26a0;"
 - unicodemath:
   - therefore
-  - __{:.}
-  - __{wasytherefore}
+  - '"P{:.}"'
+  - '"P{wasytherefore}"'
   asciimath:
   - therefore
   - ":."
-  - __{wasytherefore}
+  - '"P{wasytherefore}"'
   mathml:
   - "&#x2234;"
   latex:
   - wasytherefore
   - therefore
-  - __{:.}
+  - "\\text{P[:.]}"
   omml:
   - "&#x2234;"
   html:
   - "&#x2234;"
 - unicodemath:
   - wedge
-  - __{^^}
-  - __{land}
+  - '"P{^^}"'
+  - '"P{land}"'
   asciimath:
   - wedge
   - "^^"
-  - __{land}
+  - '"P{land}"'
   mathml:
   - "&#x2227;"
   latex:
   - wedge
   - land
-  - __{^^}
+  - "\\text{P[^^]}"
   omml:
   - "&#x2227;"
   html:
   - "&#x2227;"
 - unicodemath:
-  - __{wedgebar}
+  - '"P{wedgebar}"'
   asciimath:
-  - __{wedgebar}
+  - '"P{wedgebar}"'
   mathml:
   - "&#x2a5f;"
   latex:
@@ -18358,9 +18357,9 @@
   html:
   - "&#x2a5f;"
 - unicodemath:
-  - __{wedgedot}
+  - '"P{wedgedot}"'
   asciimath:
-  - __{wedgedot}
+  - '"P{wedgedot}"'
   mathml:
   - "&#x27d1;"
   latex:
@@ -18370,9 +18369,9 @@
   html:
   - "&#x27d1;"
 - unicodemath:
-  - __{wedgedoublebar}
+  - '"P{wedgedoublebar}"'
   asciimath:
-  - __{wedgedoublebar}
+  - '"P{wedgedoublebar}"'
   mathml:
   - "&#x2a60;"
   latex:
@@ -18382,9 +18381,9 @@
   html:
   - "&#x2a60;"
 - unicodemath:
-  - __{wedgemidvert}
+  - '"P{wedgemidvert}"'
   asciimath:
-  - __{wedgemidvert}
+  - '"P{wedgemidvert}"'
   mathml:
   - "&#x2a5a;"
   latex:
@@ -18394,9 +18393,9 @@
   html:
   - "&#x2a5a;"
 - unicodemath:
-  - __{wedgeodot}
+  - '"P{wedgeodot}"'
   asciimath:
-  - __{wedgeodot}
+  - '"P{wedgeodot}"'
   mathml:
   - "&#x2a51;"
   latex:
@@ -18406,9 +18405,9 @@
   html:
   - "&#x2a51;"
 - unicodemath:
-  - __{wedgeonwedge}
+  - '"P{wedgeonwedge}"'
   asciimath:
-  - __{wedgeonwedge}
+  - '"P{wedgeonwedge}"'
   mathml:
   - "&#x2a55;"
   latex:
@@ -18418,9 +18417,9 @@
   html:
   - "&#x2a55;"
 - unicodemath:
-  - __{whitearrowupfrombar}
+  - '"P{whitearrowupfrombar}"'
   asciimath:
-  - __{whitearrowupfrombar}
+  - '"P{whitearrowupfrombar}"'
   mathml:
   - "&#x21ea;"
   latex:
@@ -18430,9 +18429,9 @@
   html:
   - "&#x21ea;"
 - unicodemath:
-  - __{whiteinwhitetriangle}
+  - '"P{whiteinwhitetriangle}"'
   asciimath:
-  - __{whiteinwhitetriangle}
+  - '"P{whiteinwhitetriangle}"'
   mathml:
   - "&#x27c1;"
   latex:
@@ -18442,9 +18441,9 @@
   html:
   - "&#x27c1;"
 - unicodemath:
-  - __{whitepointerleft}
+  - '"P{whitepointerleft}"'
   asciimath:
-  - __{whitepointerleft}
+  - '"P{whitepointerleft}"'
   mathml:
   - "&#x25c5;"
   latex:
@@ -18454,9 +18453,9 @@
   html:
   - "&#x25c5;"
 - unicodemath:
-  - __{whitepointerright}
+  - '"P{whitepointerright}"'
   asciimath:
-  - __{whitepointerright}
+  - '"P{whitepointerright}"'
   mathml:
   - "&#x25bb;"
   latex:
@@ -18466,9 +18465,9 @@
   html:
   - "&#x25bb;"
 - unicodemath:
-  - __{whitesquaretickleft}
+  - '"P{whitesquaretickleft}"'
   asciimath:
-  - __{whitesquaretickleft}
+  - '"P{whitesquaretickleft}"'
   mathml:
   - "&#x27e4;"
   latex:
@@ -18478,9 +18477,9 @@
   html:
   - "&#x27e4;"
 - unicodemath:
-  - __{whitesquaretickright}
+  - '"P{whitesquaretickright}"'
   asciimath:
-  - __{whitesquaretickright}
+  - '"P{whitesquaretickright}"'
   mathml:
   - "&#x27e5;"
   latex:
@@ -18490,9 +18489,9 @@
   html:
   - "&#x27e5;"
 - unicodemath:
-  - __{whthorzoval}
+  - '"P{whthorzoval}"'
   asciimath:
-  - __{whthorzoval}
+  - '"P{whthorzoval}"'
   mathml:
   - "&#x2b2d;"
   latex:
@@ -18502,9 +18501,9 @@
   html:
   - "&#x2b2d;"
 - unicodemath:
-  - __{whtvertoval}
+  - '"P{whtvertoval}"'
   asciimath:
-  - __{whtvertoval}
+  - '"P{whtvertoval}"'
   mathml:
   - "&#x2b2f;"
   latex:
@@ -18514,9 +18513,9 @@
   html:
   - "&#x2b2f;"
 - unicodemath:
-  - __{wideangledown}
+  - '"P{wideangledown}"'
   asciimath:
-  - __{wideangledown}
+  - '"P{wideangledown}"'
   mathml:
   - "&#x29a6;"
   latex:
@@ -18526,9 +18525,9 @@
   html:
   - "&#x29a6;"
 - unicodemath:
-  - __{wideangleup}
+  - '"P{wideangleup}"'
   asciimath:
-  - __{wideangleup}
+  - '"P{wideangleup}"'
   mathml:
   - "&#x29a7;"
   latex:
@@ -18538,9 +18537,9 @@
   html:
   - "&#x29a7;"
 - unicodemath:
-  - __{widebridgeabove}
+  - '"P{widebridgeabove}"'
   asciimath:
-  - __{widebridgeabove}
+  - '"P{widebridgeabove}"'
   mathml:
   - "&#x20e9;"
   latex:
@@ -18550,11 +18549,11 @@
   html:
   - "&#x20e9;"
 - unicodemath:
-  - __{overparen}
-  - __{wideparen}
+  - '"P{overparen}"'
+  - '"P{wideparen}"'
   asciimath:
-  - __{overparen}
-  - __{wideparen}
+  - '"P{overparen}"'
+  - '"P{wideparen}"'
   mathml:
   - "&#x23dc;"
   latex:
@@ -18567,7 +18566,7 @@
 - unicodemath:
   - wp
   asciimath:
-  - __{wp}
+  - '"P{wp}"'
   mathml:
   - "&#x2118;"
   latex:
@@ -18579,7 +18578,7 @@
 - unicodemath:
   - wr
   asciimath:
-  - __{wr}
+  - '"P{wr}"'
   mathml:
   - "&#x2240;"
   latex:
@@ -18589,9 +18588,9 @@
   html:
   - "&#x2240;"
 - unicodemath:
-  - __{XBox}
+  - '"P{XBox}"'
   asciimath:
-  - __{XBox}
+  - '"P{XBox}"'
   mathml:
   - "&#x2612;"
   latex:
@@ -18602,10 +18601,10 @@
   - "&#x2612;"
 - unicodemath:
   - xi
-  - __{upxi}
+  - '"P{upxi}"'
   asciimath:
   - xi
-  - __{upxi}
+  - '"P{upxi}"'
   mathml:
   - "&#x3be;"
   latex:
@@ -18616,9 +18615,9 @@
   html:
   - "&#x3be;"
 - unicodemath:
-  - __{xsol}
+  - '"P{xsol}"'
   asciimath:
-  - __{xsol}
+  - '"P{xsol}"'
   mathml:
   - "&#x29f8;"
   latex:
@@ -18629,7 +18628,7 @@
   - "&#x29f8;"
 - unicodemath:
   - times
-  - __{xx}
+  - '"P{xx}"'
   asciimath:
   - times
   - xx
@@ -18637,15 +18636,15 @@
   - "&#xd7;"
   latex:
   - times
-  - __{xx}
+  - "\\text{P[xx]}"
   omml:
   - "&#xd7;"
   html:
   - "&#xd7;"
 - unicodemath:
-  - __{yen}
+  - '"P{yen}"'
   asciimath:
-  - __{yen}
+  - '"P{yen}"'
   mathml:
   - "&#xa5;"
   latex:
@@ -18655,9 +18654,9 @@
   html:
   - "&#xa5;"
 - unicodemath:
-  - __{yinyang}
+  - '"P{yinyang}"'
   asciimath:
-  - __{yinyang}
+  - '"P{yinyang}"'
   mathml:
   - "&#x262f;"
   latex:
@@ -18667,9 +18666,9 @@
   html:
   - "&#x262f;"
 - unicodemath:
-  - __{Yup}
+  - '"P{Yup}"'
   asciimath:
-  - __{Yup}
+  - '"P{Yup}"'
   mathml:
   - "&#x2144;"
   latex:
@@ -18679,9 +18678,9 @@
   html:
   - "&#x2144;"
 - unicodemath:
-  - __{Zbar}
+  - '"P{Zbar}"'
   asciimath:
-  - __{Zbar}
+  - '"P{Zbar}"'
   mathml:
   - "&#x1b5;"
   latex:
@@ -18692,10 +18691,10 @@
   - "&#x1b5;"
 - unicodemath:
   - zeta
-  - __{upzeta}
+  - '"P{upzeta}"'
   asciimath:
   - zeta
-  - __{upzeta}
+  - '"P{upzeta}"'
   mathml:
   - "&#x3b6;"
   latex:
@@ -18706,9 +18705,9 @@
   html:
   - "&#x3b6;"
 - unicodemath:
-  - __{zpipe}
+  - '"P{zpipe}"'
   asciimath:
-  - __{zpipe}
+  - '"P{zpipe}"'
   mathml:
   - "&#x2a20;"
   latex:
@@ -18720,11 +18719,11 @@
 - unicodemath:
   - zwnj
   asciimath:
-  - __{zwnj}
+  - '"P{zwnj}"'
   mathml:
   - "&#x200c;"
   latex:
-  - __{zwnj}
+  - "\\text{P[zwnj]}"
   omml:
   - "&#x200c;"
   html:
@@ -18732,19 +18731,19 @@
 - unicodemath:
   - zwsp
   asciimath:
-  - __{zwsp}
+  - '"P{zwsp}"'
   mathml:
   - "&#x200b;"
   latex:
-  - __{zwsp}
+  - "\\text{P[zwsp]}"
   omml:
   - "&#x200b;"
   html:
   - "&#x200b;"
 - unicodemath:
-  - __{ZZ}
+  - '"P{ZZ}"'
   asciimath:
-  - __{ZZ}
+  - ZZ
   mathml:
   - "&#x2124;"
   latex:

--- a/_tasks/plurimath_supported_symbols.rake
+++ b/_tasks/plurimath_supported_symbols.rake
@@ -3,9 +3,7 @@ require "plurimath"
 task :symbols_yaml_file do
   utility = Plurimath::Utility
   symbols_array = []
-  utility.symbols_files.each do |file_path|
-    file_name = File.basename(file_path, ".rb")
-    symbol_object = utility.get_symbol_class(file_name)
+  utility.symbols_files.each do |symbol_object|
     temp_hash = {}
     symbol_object::INPUT.map do |lang, symbols|
       symbols.flatten!


### PR DESCRIPTION
This PR updates the lists of symbols available at: https://plurimath.org/symbols with the latest symbols and wrapper syntaxes.
Additionally, this PR updates the rake task to use the latest Plurimath version.

closes #62 